### PR TITLE
fix(frontend): WS singleton — survive React StrictMode mount/unmount

### DIFF
--- a/frontend/src/app/providers/WebSocketProvider.tsx
+++ b/frontend/src/app/providers/WebSocketProvider.tsx
@@ -13,10 +13,14 @@ export function WebSocketProvider({
     url = DEFAULT_URL,
 }: WebSocketProviderProps): ReactElement {
     useEffect(() => {
+        // Singleton WS — connect is idempotent. We deliberately do NOT
+        // disconnect on unmount: under React 18 StrictMode the cleanup
+        // fires during the dev double-mount and was racing the still-
+        // CONNECTING socket, producing "closed before established" errors
+        // and the backend "Cannot write to closing transport" warnings.
+        // The socket lives for the lifetime of the tab; the browser will
+        // close it on tab-close, which is sufficient.
         wsClient.connect(url);
-        return () => {
-            wsClient.disconnect();
-        };
     }, [url]);
 
     return <>{children}</>;

--- a/frontend/src/core/websocket/wsClient.ts
+++ b/frontend/src/core/websocket/wsClient.ts
@@ -65,7 +65,17 @@ class WsClientImpl implements WsClient {
     // ---------------------------------------------------------------------------
 
     connect(url: string): void {
-        if (this.destroyed) return;
+        // Idempotent: if already connecting/open to the same URL, no-op.
+        // This makes the call safe under React 18 StrictMode, where the
+        // WebSocketProvider's effect runs mount → unmount → remount in dev,
+        // and the provider may also re-render under HMR.
+        if (this.url === url && this.ws !== null && this.state !== 'closed') {
+            return;
+        }
+        // Switching URLs (rare): tear down first.
+        if (this.ws !== null) {
+            this.tearDown();
+        }
         this.url = url;
         this.destroyed = false;
         this.openSocket();
@@ -73,13 +83,21 @@ class WsClientImpl implements WsClient {
 
     disconnect(): void {
         this.destroyed = true;
+        this.tearDown();
+    }
+
+    private tearDown(): void {
         if (this.reconnectTimer !== null) {
             clearTimeout(this.reconnectTimer);
             this.reconnectTimer = null;
         }
-        if (this.ws) {
+        if (this.ws !== null) {
             this.ws.onclose = null;
-            this.ws.close();
+            try {
+                this.ws.close();
+            } catch {
+                // ignore — close on a CONNECTING socket is best-effort
+            }
             this.ws = null;
         }
         this.setReadyState('closed');


### PR DESCRIPTION
## Summary
HUD couldn't keep its WebSocket open in dev — Wake-Word never got mic frames. Two combined bugs in the singleton WS path:

1. \`WebSocketProvider.tsx\`'s \`useEffect\` cleanup called \`wsClient.disconnect()\` on unmount. React 18 StrictMode runs every dev effect mount → cleanup → remount, racing the still-CONNECTING socket. Result: backend logs \`Cannot write to closing transport\` within 2 s of every connect.
2. \`wsClient.connect()\` early-returned when \`this.destroyed === true\`. The StrictMode disconnect set \`destroyed=true\`, so the remount's connect was silently ignored. The socket stayed dead.

## What changed
- **\`frontend/src/core/websocket/wsClient.ts\`**: \`connect()\` is now idempotent — returns early if already connected to the same URL, otherwise tears down and reopens. \`disconnect()\` keeps its public semantics; cleanup logic moved to a private \`tearDown()\` that catches close() exceptions on CONNECTING sockets.
- **\`frontend/src/app/providers/WebSocketProvider.tsx\`**: dropped the cleanup return. The singleton WS lives for the tab lifetime; the browser closes it on tab-close, which is sufficient.

## Test plan (post-merge)
- [ ] Pull main, restart Vite, hard-reload HUD (\`Ctrl+Shift+R\`)
- [ ] Browser console: no more \`WebSocket is closed before the connection is established\` errors
- [ ] Backend log: \`Client connected. Total clients: 1\` followed by sustained activity (no \`Cannot write to closing transport\`)
- [ ] Say \"hey jarvis\" — backend should respond

## Verification already run
- \`npx vite build\` — clean, 14.34 s
- \`npx vitest run wsClient.test.ts\` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)