### PR TITLE
fix(frontend): useMicStream — resume AudioContext + unlock-on-gesture fallback

### DIFF
--- a/frontend/src/features/conversation/hooks/useMicStream.ts
+++ b/frontend/src/features/conversation/hooks/useMicStream.ts
@@ -31,6 +31,8 @@ export function useMicStream({ paused }: UseMicStreamOptions): UseMicStreamRetur
         let processorNode: ScriptProcessorNode | null = null;
         let stream: MediaStream | null = null;
         let destroyed = false;
+        let unlockListeners: (() => void) | null = null;
+        let firstFrameLogged = false;
 
         async function start(): Promise<void> {
             try {
@@ -52,6 +54,21 @@ export function useMicStream({ paused }: UseMicStreamOptions): UseMicStreamRetur
                 // Request 16 kHz explicitly; browser may not honour it — we downsample
                 // in the processor if needed.
                 audioCtx = new AudioContext({ sampleRate: 16000 });
+
+                // AudioContext starts in 'suspended' state under the autoplay policy.
+                // Resume immediately — the just-completed getUserMedia permission grant
+                // counts as a user gesture, so this should succeed without further input.
+                if (audioCtx.state === 'suspended') {
+                    try {
+                        await audioCtx.resume();
+                    } catch (err) {
+                        console.warn(
+                            '[useMicStream] AudioContext resume failed; will retry on next user gesture:',
+                            err,
+                        );
+                    }
+                }
+
                 sourceNode = audioCtx.createMediaStreamSource(stream);
 
                 // bufferSize=4096 gives ~256 ms at 16 kHz — a good balance between
@@ -67,6 +84,13 @@ export function useMicStream({ paused }: UseMicStreamOptions): UseMicStreamRetur
 
                     // Convert float32 [-1, 1] → int16 [-32768, 32767]
                     const int16 = floatToInt16(float32, inputBuffer.sampleRate);
+
+                    if (!firstFrameLogged) {
+                        console.info(
+                            `[useMicStream] First PCM frame: ${int16.length} samples, sr=${inputBuffer.sampleRate}, ctxState=${audioCtx?.state}`,
+                        );
+                        firstFrameLogged = true;
+                    }
                     wsClient.sendBinary(int16.buffer as ArrayBuffer);
                 };
 
@@ -79,12 +103,30 @@ export function useMicStream({ paused }: UseMicStreamOptions): UseMicStreamRetur
                 silentGain.connect(audioCtx.destination);
 
                 isCapturingRef.current = true;
+
+                // Belt-and-suspenders fallback: if any future tab-suspend / autoplay
+                // blip drops the context back to 'suspended', resume on next gesture.
+                const unlock = (): void => {
+                    if (audioCtx && audioCtx.state === 'suspended') {
+                        void audioCtx.resume();
+                    }
+                };
+                window.addEventListener('click', unlock);
+                window.addEventListener('keydown', unlock);
+
+                // Stash on the closure so cleanup can remove them.
+                unlockListeners = unlock;
             } catch (err) {
                 console.error('[useMicStream] Failed to start mic capture:', err);
             }
         }
 
         function stop(): void {
+            if (unlockListeners) {
+                window.removeEventListener('click', unlockListeners);
+                window.removeEventListener('keydown', unlockListeners);
+                unlockListeners = null;
+            }
             isCapturingRef.current = false;
             try {
                 processorNode?.disconnect();


### PR DESCRIPTION
## Summary
Mic stream sent **zero** PCM frames to backend despite the Chrome mic indicator + VU bar showing live audio. Root cause: \`new AudioContext({sampleRate: 16000})\` is created in \`suspended\` state under modern browsers' autoplay policy, and \`useMicStream\` never called \`resume()\`. While suspended, \`processorNode.onaudioprocess\` does not fire → \`wsClient.sendBinary\` is never called → wake-word detector never sees audio.

\`usePushToTalk.ts\` already had the resume() dance — \`useMicStream\` was missing it.

## What changed (one file: \`useMicStream.ts\`)
- After \`new AudioContext(...)\`: if \`state === 'suspended'\`, \`await audioCtx.resume()\`. The just-completed \`getUserMedia\` permission grant counts as the user gesture, so this normally succeeds without further interaction.
- Belt-and-suspenders fallback: register one-time \`click\` / \`keydown\` listeners that resume the context if it drifts back to suspended (tab blur / hardened policy browsers). Removed in \`stop()\`.
- One-time diagnostic log on the first PCM frame: \`[useMicStream] First PCM frame: N samples, sr=16000, ctxState=running\` — gives us instant DevTools confirmation that audio is actually flowing.

## Out of scope
StrictMode-double-mount race in \`useMicStream\`'s \`useEffect([], …)\` is a separate concern, deliberately not bundled here. The Voice-Pipeline Murks-Audit (running in parallel) will surface it explicitly.

## Test plan (post-merge for the user)
- [ ] Pull main, hard-reload the HUD tab
- [ ] Browser console: \`[useMicStream] First PCM frame: 4000 samples, sr=16000, ctxState=running\` should appear within 1–2 s of page load
- [ ] Backend log: with DEBUG enabled, the \`elif msg.type == web.WSMsgType.BINARY\` branch will start firing many times per second
- [ ] Say \"hey jarvis\" — backend log should show \`Wake word detected via browser audio\`

## Verification already run
- \`npx vite build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)