### PR TITLE
fix(voice-pipeline): top-3 audit findings — frozen audio queue + hardcoded linux paths

### DIFF
--- a/frontend/src/core/audio/useAudioAnalyser.ts
+++ b/frontend/src/core/audio/useAudioAnalyser.ts
@@ -80,7 +80,19 @@ export function useAudioAnalyser(): UseAudioAnalyserReturn {
 
             source.connect(gain);
             const analyserNode = analyserRef.current;
-            if (!analyserNode) return;
+            if (!analyserNode) {
+                activeSourceRef.current = null;
+                gainRef.current = null;
+                speechPlayingRef.current = false;
+                queueRef.current = queueRef.current.slice(1);
+                playingRef.current = false;
+                if (queueRef.current.length === 0) {
+                    setIsSpeaking(false);
+                } else {
+                    void playNext();
+                }
+                return;
+            }
             gain.connect(analyserNode);
 
             source.onended = () => {

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -2962,7 +2962,7 @@ async def voices_handler(request: web.Request) -> web.Response:
 # every request. Only the sections relevant to spoken announcements are kept;
 # the DM Auto-Reply Policy table is excluded (irrelevant for TTS generation).
 _soul_extract_cache: str | None = None
-_SOUL_MD_PATH: Path = Path("/home/paps/.openclaw/workspace/SOUL.md")
+_SOUL_MD_PATH: Path = Path.home() / ".openclaw" / "workspace" / "SOUL.md"
 _SOUL_SECTIONS_WANTED = {
     "## Core Directives",
     "## Response Style",

--- a/src/integrations/openclaw/ws_client.py
+++ b/src/integrations/openclaw/ws_client.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import sys
 import time
 import uuid
 from dataclasses import dataclass
@@ -501,6 +502,12 @@ class OpenClawWSClient:
         # Step 2: build signature and send connect
         role = "operator"
         signed_at_ms = int(time.time() * 1000)
+        if sys.platform == "win32":
+            platform = "win32"
+        elif sys.platform == "darwin":
+            platform = "darwin"
+        else:
+            platform = "linux"
         payload_str = _build_device_auth_payload_v3(
             device_id=device_id,
             client_id=_CLIENT_ID,
@@ -510,7 +517,7 @@ class OpenClawWSClient:
             signed_at_ms=signed_at_ms,
             token=gateway_token,
             nonce=nonce,
-            platform="linux",
+            platform=platform,
         )
         signature = _sign_device_payload(private_key_pem, payload_str)
 
@@ -521,7 +528,7 @@ class OpenClawWSClient:
                 "id": _CLIENT_ID,
                 "version": _CLIENT_VERSION,
                 "mode": _CLIENT_MODE,
-                "platform": "linux",
+                "platform": platform,
             },
             "caps": [],
             "role": role,


### PR DESCRIPTION
## Summary
Three surgical fixes from the post-Copilot voice-pipeline audit (4 critical findings; these are #1–#3, the highest-leverage ones).

## What changed
- **\`frontend/src/core/audio/useAudioAnalyser.ts\`** — null-analyser guard in \`playNext()\` cleant up state and drains queue instead of bare \`return\`. Without this, JARVIS would silently stop speaking after any AudioContext-Churn-Event (tab visibility, context close).
- **\`src/integrations/openclaw/ws_client.py\`** — \`platform\` in the Ed25519 connect payload now derives from \`sys.platform\` (\`win32\` / \`darwin\` / \`linux\`). Was hardcoded \`\"linux\"\` — we were sending a mismatched signed claim from any non-Linux host.
- **\`src/api/ws_server.py\`** — \`_SOUL_MD_PATH = Path.home() / \".openclaw\" / \"workspace\" / \"SOUL.md\"\`. Was \`Path(\"/home/paps/...\")\` — silently empty SOUL on every non-paps machine, killing wife-notification persona fidelity.

## Out of scope (separate batches)
- \`asyncio.get_event_loop()\` deprecations (~10 sites)
- \`os.environ.get()\` in feature code (config-layer violation)
- \`play_duration = max(...) / 2000\` magic-number sleep blocking the asyncio task in \`ws_server.py:2046\`
- \`httpx.AsyncClient\` re-creation per TTS call in \`fish_tts.py\`
- \`WAKE_GUARD_MS\` dead-stub in \`useAudioEngine.ts\`
- German-sentence splitter in \`stream_splitter.py\`
- StrictMode-double-mount race in \`useMicStream.ts\`
- Server-side \`sounddevice\` calls in \`wake_word.py\` / \`tts.py\` (legacy-mode dead code in browser-audio deployment)

## Test plan
- [ ] Backend restart needed for fixes #2 + #3 to take effect (Python doesn't hot-reload)
- [ ] Frontend Vite-HMR picks up #1
- [ ] Manual: say \"hey jarvis\" → JARVIS still responds (regression check)
- [ ] Manual: tab-blur for ~30 s, tab-focus, say \"hey jarvis\" → still responds (would have hit the frozen-queue bug)

## Verification already run
- \`npx vite build\` — clean
- \`python -c \"ast.parse(...)\"\` for both Python files — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)