### PR TITLE
fix(voice-pipeline): audit batch 2 — latency, stability, dead-code

### DIFF
--- a/frontend/src/core/audio/useAudioEngine.ts
+++ b/frontend/src/core/audio/useAudioEngine.ts
@@ -14,7 +14,6 @@ const STORAGE_KEY = 'jarvis.sfx.muted';
 const IDLE_TIMEOUT_MS = 30_000;
 const DISCONNECT_SFX_GATE_MS = 5_000;
 const OFFLINE_DELAY_MS = 3_000;
-const WAKE_GUARD_MS = 500;
 
 function readStoredMute(): boolean {
     try {
@@ -56,7 +55,6 @@ export function useAudioEngine(
 
     const bootFiredRef = useRef(false);
     const prevOrbStateRef = useRef<AppOrbState | null>(null);
-    const wakeGuardActiveRef = useRef(false);
 
     const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const disconnectSfxTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -159,10 +157,7 @@ export function useAudioEngine(
         if (prev === orbState) return;
 
         if (prev !== null) {
-            const suppressStateChange = orbState === 'listening' && wakeGuardActiveRef.current;
-            if (!suppressStateChange) {
-                engine.playOneShot('state_change');
-            }
+            engine.playOneShot('state_change');
         }
 
         if (prev === 'listening') {
@@ -286,8 +281,6 @@ export function useAudioEngine(
     const stop = useCallback((event: SfxEvent) => {
         engineRef.current.stop(event);
     }, []);
-
-    void WAKE_GUARD_MS;
 
     return {
         isMuted,

--- a/frontend/src/features/conversation/hooks/useMicStream.ts
+++ b/frontend/src/features/conversation/hooks/useMicStream.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { wsClient } from '@core/websocket/wsClient';
-import type { UseMicStreamOptions, UseMicStreamReturn } from './useMicStream.types';
+import type { MicSessionState, UseMicStreamOptions, UseMicStreamReturn } from './useMicStream.types';
 
 /**
  * Hook that captures raw microphone audio in the browser and streams
@@ -12,148 +12,198 @@ import type { UseMicStreamOptions, UseMicStreamReturn } from './useMicStream.typ
  *
  * When `paused` is true no frames are sent (used while JARVIS is speaking
  * to prevent feedback).
+ *
+ * Uses a module-level singleton to be idempotent under React 18 StrictMode
+ * (mount → cleanup-unmount → remount). A refCount guards start/stop so the
+ * AudioContext is created once per tab lifetime, not once per render cycle.
  */
+
+// ---------------------------------------------------------------------------
+// Module-level singleton — mirrors wsClient singleton pattern
+// ---------------------------------------------------------------------------
+
+const session: MicSessionState = {
+    audioCtx: null,
+    sourceNode: null,
+    processorNode: null,
+    silentGain: null,
+    stream: null,
+    unlockHandler: null,
+    starting: false,
+    refCount: 0,
+    firstFrameLogged: false,
+    pausedRef: null,
+};
+
+async function startMicSession(pausedRef: React.RefObject<boolean>): Promise<void> {
+    // Idempotent: if already running or starting, bail out immediately.
+    if (session.audioCtx !== null || session.starting) {
+        return;
+    }
+
+    session.starting = true;
+    // Store the ref so onaudioprocess can read it from the singleton.
+    session.pausedRef = pausedRef;
+
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+            audio: {
+                channelCount: 1,
+                sampleRate: 16000,
+                echoCancellation: true,
+                noiseSuppression: true,
+                autoGainControl: true,
+            },
+        });
+
+        // If the session was torn down while getUserMedia was in-flight, discard.
+        if (session.starting === false) {
+            stream.getTracks().forEach((t) => t.stop());
+            return;
+        }
+
+        session.stream = stream;
+
+        // Request 16 kHz explicitly; browser may not honour it — we downsample
+        // in the processor if needed.
+        const audioCtx = new AudioContext({ sampleRate: 16000 });
+        session.audioCtx = audioCtx;
+
+        // AudioContext starts in 'suspended' state under the autoplay policy.
+        // Resume immediately — the just-completed getUserMedia permission grant
+        // counts as a user gesture, so this should succeed without further input.
+        if (audioCtx.state === 'suspended') {
+            try {
+                await audioCtx.resume();
+            } catch (err) {
+                console.warn(
+                    '[useMicStream] AudioContext resume failed; will retry on next user gesture:',
+                    err,
+                );
+            }
+        }
+
+        session.sourceNode = audioCtx.createMediaStreamSource(stream);
+
+        // bufferSize=4096 gives ~256 ms at 16 kHz — a good balance between
+        // latency and CPU. Use mono (1 channel).
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        session.processorNode = audioCtx.createScriptProcessor(4096, 1, 1);
+
+        session.processorNode.onaudioprocess = (event: AudioProcessingEvent) => {
+            // Read paused state from the singleton's pausedRef slot.
+            if (session.pausedRef?.current) return;
+
+            const inputBuffer = event.inputBuffer;
+            const float32 = inputBuffer.getChannelData(0);
+
+            // Convert float32 [-1, 1] → int16 [-32768, 32767]
+            const int16 = floatToInt16(float32, inputBuffer.sampleRate);
+
+            if (!session.firstFrameLogged) {
+                console.info(
+                    `[useMicStream] First PCM frame: ${int16.length} samples, sr=${inputBuffer.sampleRate}, ctxState=${session.audioCtx?.state}`,
+                );
+                session.firstFrameLogged = true;
+            }
+            wsClient.sendBinary(int16.buffer as ArrayBuffer);
+        };
+
+        session.sourceNode.connect(session.processorNode);
+
+        // Connect to destination with zero gain so the browser doesn't echo
+        // the mic back to the speakers but still runs the graph.
+        const silentGain = audioCtx.createGain();
+        silentGain.gain.value = 0;
+        session.processorNode.connect(silentGain);
+        silentGain.connect(audioCtx.destination);
+        session.silentGain = silentGain;
+
+        // Belt-and-suspenders fallback: if any future tab-suspend / autoplay
+        // blip drops the context back to 'suspended', resume on next gesture.
+        const unlock = (): void => {
+            if (session.audioCtx && session.audioCtx.state === 'suspended') {
+                void session.audioCtx.resume();
+            }
+        };
+        window.addEventListener('click', unlock);
+        window.addEventListener('keydown', unlock);
+        session.unlockHandler = unlock;
+    } catch (err) {
+        console.error('[useMicStream] Failed to start mic capture:', err);
+    } finally {
+        session.starting = false;
+    }
+}
+
+function stopMicSession(): void {
+    if (session.unlockHandler) {
+        window.removeEventListener('click', session.unlockHandler);
+        window.removeEventListener('keydown', session.unlockHandler);
+        session.unlockHandler = null;
+    }
+    try {
+        session.processorNode?.disconnect();
+        session.sourceNode?.disconnect();
+        session.audioCtx?.close();
+    } catch {
+        // ignore cleanup errors
+    }
+    session.stream?.getTracks().forEach((t) => t.stop());
+    session.processorNode = null;
+    session.sourceNode = null;
+    session.audioCtx = null;
+    session.silentGain = null;
+    session.stream = null;
+    session.pausedRef = null;
+    session.firstFrameLogged = false;
+    // starting is reset in the finally block of startMicSession, but be safe.
+    session.starting = false;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useMicStream({ paused }: UseMicStreamOptions): UseMicStreamReturn {
-    const isCapturingRef = useRef(false);
     const pausedRef = useRef(paused);
 
-    // Keep pausedRef in sync without restarting the stream
+    // Keep pausedRef in sync without restarting the stream.
     useEffect(() => {
         pausedRef.current = paused;
     }, [paused]);
 
     useEffect(() => {
-        let audioCtx: AudioContext | null = null;
-        let sourceNode: MediaStreamAudioSourceNode | null = null;
-        // ScriptProcessorNode is deprecated but has the widest browser support
-        // for real-time raw PCM access without an AudioWorklet bundler setup.
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        let processorNode: ScriptProcessorNode | null = null;
-        let stream: MediaStream | null = null;
-        let destroyed = false;
-        let unlockListeners: (() => void) | null = null;
-        let firstFrameLogged = false;
+        session.refCount += 1;
 
-        async function start(): Promise<void> {
-            try {
-                stream = await navigator.mediaDevices.getUserMedia({
-                    audio: {
-                        channelCount: 1,
-                        sampleRate: 16000,
-                        echoCancellation: true,
-                        noiseSuppression: true,
-                        autoGainControl: true,
-                    },
-                });
-
-                if (destroyed) {
-                    stream.getTracks().forEach((t) => t.stop());
-                    return;
-                }
-
-                // Request 16 kHz explicitly; browser may not honour it — we downsample
-                // in the processor if needed.
-                audioCtx = new AudioContext({ sampleRate: 16000 });
-
-                // AudioContext starts in 'suspended' state under the autoplay policy.
-                // Resume immediately — the just-completed getUserMedia permission grant
-                // counts as a user gesture, so this should succeed without further input.
-                if (audioCtx.state === 'suspended') {
-                    try {
-                        await audioCtx.resume();
-                    } catch (err) {
-                        console.warn(
-                            '[useMicStream] AudioContext resume failed; will retry on next user gesture:',
-                            err,
-                        );
-                    }
-                }
-
-                sourceNode = audioCtx.createMediaStreamSource(stream);
-
-                // bufferSize=4096 gives ~256 ms at 16 kHz — a good balance between
-                // latency and CPU. Use mono (1 channel).
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
-                processorNode = audioCtx.createScriptProcessor(4096, 1, 1);
-
-                processorNode.onaudioprocess = (event: AudioProcessingEvent) => {
-                    if (pausedRef.current) return;
-
-                    const inputBuffer = event.inputBuffer;
-                    const float32 = inputBuffer.getChannelData(0);
-
-                    // Convert float32 [-1, 1] → int16 [-32768, 32767]
-                    const int16 = floatToInt16(float32, inputBuffer.sampleRate);
-
-                    if (!firstFrameLogged) {
-                        console.info(
-                            `[useMicStream] First PCM frame: ${int16.length} samples, sr=${inputBuffer.sampleRate}, ctxState=${audioCtx?.state}`,
-                        );
-                        firstFrameLogged = true;
-                    }
-                    wsClient.sendBinary(int16.buffer as ArrayBuffer);
-                };
-
-                sourceNode.connect(processorNode);
-                // Connect to destination with zero gain so the browser doesn't echo
-                // the mic back to the speakers but still runs the graph.
-                const silentGain = audioCtx.createGain();
-                silentGain.gain.value = 0;
-                processorNode.connect(silentGain);
-                silentGain.connect(audioCtx.destination);
-
-                isCapturingRef.current = true;
-
-                // Belt-and-suspenders fallback: if any future tab-suspend / autoplay
-                // blip drops the context back to 'suspended', resume on next gesture.
-                const unlock = (): void => {
-                    if (audioCtx && audioCtx.state === 'suspended') {
-                        void audioCtx.resume();
-                    }
-                };
-                window.addEventListener('click', unlock);
-                window.addEventListener('keydown', unlock);
-
-                // Stash on the closure so cleanup can remove them.
-                unlockListeners = unlock;
-            } catch (err) {
-                console.error('[useMicStream] Failed to start mic capture:', err);
-            }
+        if (session.refCount === 1) {
+            void startMicSession(pausedRef);
         }
-
-        function stop(): void {
-            if (unlockListeners) {
-                window.removeEventListener('click', unlockListeners);
-                window.removeEventListener('keydown', unlockListeners);
-                unlockListeners = null;
-            }
-            isCapturingRef.current = false;
-            try {
-                processorNode?.disconnect();
-                sourceNode?.disconnect();
-                audioCtx?.close();
-            } catch {
-                // ignore cleanup errors
-            }
-            stream?.getTracks().forEach((t) => t.stop());
-            processorNode = null;
-            sourceNode = null;
-            audioCtx = null;
-            stream = null;
-        }
-
-        void start();
 
         return () => {
-            destroyed = true;
-            stop();
+            session.refCount -= 1;
+
+            if (session.refCount === 0) {
+                // Defer stop slightly so StrictMode's unmount/remount cycle
+                // (mount → cleanup → remount in dev) doesn't churn the AudioContext.
+                setTimeout(() => {
+                    if (session.refCount === 0) {
+                        stopMicSession();
+                    }
+                }, 100);
+            }
         };
         // We intentionally run this once — wsClient is a module-level singleton
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    return { isCapturing: isCapturingRef.current };
+    // isCapturing is true when the AudioContext is live.
+    return { isCapturing: session.audioCtx !== null };
 }
+
+// ---------------------------------------------------------------------------
+// Helpers (module-scope, not exported — consumed only inside this file)
+// ---------------------------------------------------------------------------
 
 /**
  * Convert a Float32Array of audio samples to an Int16Array.

--- a/frontend/src/features/conversation/hooks/useMicStream.types.ts
+++ b/frontend/src/features/conversation/hooks/useMicStream.types.ts
@@ -6,3 +6,26 @@ export interface UseMicStreamOptions {
 export interface UseMicStreamReturn {
     isCapturing: boolean;
 }
+
+/**
+ * Module-level singleton state for the mic capture session.
+ * Lives outside the React component to survive StrictMode mount/unmount/remount.
+ */
+export interface MicSessionState {
+    audioCtx: AudioContext | null;
+    sourceNode: MediaStreamAudioSourceNode | null;
+    // ScriptProcessorNode is deprecated but has the widest browser support
+    // for real-time raw PCM access without an AudioWorklet bundler setup.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    processorNode: ScriptProcessorNode | null;
+    silentGain: GainNode | null;
+    stream: MediaStream | null;
+    unlockHandler: (() => void) | null;
+    /** True while getUserMedia + AudioContext setup is in-flight. */
+    starting: boolean;
+    /** Active mount count; start fires at 1, stop fires at 0. */
+    refCount: number;
+    firstFrameLogged: boolean;
+    /** Ref forwarded from the hook so onaudioprocess can read paused state. */
+    pausedRef: React.RefObject<boolean> | null;
+}

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -949,8 +949,9 @@ async def _broadcast(message: str) -> None:
     if not _connected_clients:
         return
 
+    clients = list(_connected_clients)
     disconnected = set()
-    for ws in _connected_clients:
+    for ws in clients:
         try:
             await ws.send_str(message)
         except Exception as e:
@@ -2043,8 +2044,6 @@ async def _run_voice_pipeline_body(
                 )
                 audio_b64 = base64.b64encode(audio_bytes).decode("utf-8")
                 await broadcast_audio(audio_b64, closing)
-                play_duration = max(1.2, len(audio_bytes) / 2000)
-                await asyncio.sleep(play_duration)
             except FishTTSError as exc:
                 logger.error(f"Fish TTS error during sleep close: {exc}")
 
@@ -3876,6 +3875,13 @@ async def start_ws_server(
             logger.warning("http_runner cleanup timed out after 5 s — forcing shutdown")
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"http_runner cleanup failed: {exc}")
+
+        # Close Fish TTS persistent httpx client.
+        if _fish_tts is not None:
+            try:
+                await _fish_tts.aclose()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"Fish TTS client close failed: {exc}")
 
         # Close OpenClaw + MemoryStore.
         if _openclaw_client is not None:

--- a/src/audio/barge_in.py
+++ b/src/audio/barge_in.py
@@ -112,10 +112,10 @@ class BargeInDetector:
 
                 if is_speech:
                     if speech_start is None:
-                        speech_start = asyncio.get_event_loop().time()
+                        speech_start = asyncio.get_running_loop().time()
                     else:
                         duration_ms = (
-                            asyncio.get_event_loop().time() - speech_start
+                            asyncio.get_running_loop().time() - speech_start
                         ) * 1000
 
                         if duration_ms >= self._sensitivity_ms:

--- a/src/audio/fish_tts.py
+++ b/src/audio/fish_tts.py
@@ -92,9 +92,22 @@ class FishTTSClient:
         self._api_key = api_key or os.environ.get("FISH_API_KEY", "")
         self._voice_id = voice_id or os.environ.get("FISH_VOICE_ID", "")
         self._format = format
+        self._client: httpx.AsyncClient | None = None
 
         if not self._api_key:
             logger.warning("FISH_API_KEY not set — Fish TTS will fail at runtime")
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Return the shared httpx client, creating it lazily on first call."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=30.0)
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the shared httpx client and release its resources. Idempotent."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
 
     async def synthesize(
         self,
@@ -146,8 +159,8 @@ class FishTTSClient:
                 _prosody_energy_warned = True
 
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.post(FISH_API_URL, headers=headers, json=payload)
+            client = await self._get_client()
+            response = await client.post(FISH_API_URL, headers=headers, json=payload)
 
             if response.status_code != 200:
                 raise FishTTSError(

--- a/src/audio/stream_splitter.py
+++ b/src/audio/stream_splitter.py
@@ -78,7 +78,7 @@ class StreamSplitter:
             Complete sentences ready for TTS.
         """
         self._buffer = ""
-        last_yield_time = asyncio.get_event_loop().time()
+        last_yield_time = asyncio.get_running_loop().time()
 
         async for token in token_stream:
             self._buffer += token
@@ -93,10 +93,10 @@ class StreamSplitter:
                     if sentence:
                         logger.debug(f"Yielding sentence ({len(sentence)} chars)")
                         yield sentence
-                        last_yield_time = asyncio.get_event_loop().time()
+                        last_yield_time = asyncio.get_running_loop().time()
 
             # Check for max wait timeout
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             elapsed_ms = (current_time - last_yield_time) * 1000
 
             if elapsed_ms > self._max_wait_ms and len(self._buffer) > self._min_chars:

--- a/src/audio/stt.py
+++ b/src/audio/stt.py
@@ -51,7 +51,7 @@ class SpeechToText:
 
     async def initialize(self) -> None:
         """Load the Whisper model."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def load_model() -> Any:
             try:

--- a/src/audio/tts.py
+++ b/src/audio/tts.py
@@ -90,7 +90,7 @@ class TTSEngine(ABC):
             audio_data: Audio samples as numpy array
             sample_rate: Sample rate in Hz
         """
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
 
         def callback(

--- a/src/audio/wake_word.py
+++ b/src/audio/wake_word.py
@@ -52,7 +52,7 @@ class WakeWordDetector:
 
     async def initialize(self) -> None:
         """Load the wake word model and chime sound."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def load_model() -> Any:
             try:

--- a/src/integrations/openclaw/ws_client.py
+++ b/src/integrations/openclaw/ws_client.py
@@ -195,7 +195,8 @@ def _load_gateway_token() -> str:
         cfg = json.loads(_CONFIG_FILE.read_text())
         token: str | None = cfg.get("gateway", {}).get("auth", {}).get("token")
         return token if token else ""
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"Failed to load gateway token from {_CONFIG_FILE}: {exc}")
         return ""
 
 


### PR DESCRIPTION
## Summary
Five backend + two frontend surgical fixes from the post-Copilot voice-pipeline audit (the high-leverage Warnings tier from the prior critical-tier PR #67).

## Backend
- **\`fish_tts.py\`** — persistent \`httpx.AsyncClient\` with lazy init + \`aclose()\`. Saves 4–6 TLS handshakes per multi-sentence turn → measurable first-audio latency reduction.
- **\`ws_server.py:2046\`** — removed magic-number sleep (\`max(1.2, len(audio_bytes)/2000)\`) that blocked the asyncio task on sleep-phrase turns. Wrong formula AND harmful — frontend plays audio async anyway.
- **\`ws_client.py:197\`** — \`_load_gateway_token\` bare-\`except\` now logs the swallowed exception so a missing/corrupt token surfaces immediately.
- **\`asyncio.get_event_loop()\` → \`get_running_loop()\`** in 5 async contexts (wake_word, stt, tts, barge_in, stream_splitter). Sync callers left alone.
- **\`_broadcast\` set snapshot** — list(_connected_clients) before iteration; concurrent handler mutations during \`await ws.send_str()\` can't race anymore.

## Frontend
- **\`useMicStream.ts\`** — module-level mic session singleton with refcount + 100 ms deferred stop. StrictMode mount/unmount/remount no longer churns the AudioContext or double-calls getUserMedia. Same pattern as the WS singleton fix in PR #65.
- **\`useAudioEngine.ts\`** — removed \`WAKE_GUARD_MS\` dead-stub (the const, the never-set ref, the suppressStateChange branch, the \`void\` no-op). Verified across src/ that the ref never had a setter.

## Verification already run
- \`npx vite build\` — clean
- \`npx vitest run\` — 62 files, 584 tests, 0 failures
- All Python files AST-parse + smoke import succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)