### PR TITLE
chore(greeting): default language DE + 'Alle Systeme nominal'

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -217,6 +217,7 @@ persona:
   salutation_weights: [0.5, 0.5]  # must sum to 1.0
   salutation_seed: null  # optional: integer seed for reproducibility
   salutation_override: null  # set to force specific salutation
+  default_language: "de"   # used by the online greeting and any other persona-aware utterances
   style: "jarvis"
   language_style:
     en: british_formal

--- a/src/brain/online_greeting.py
+++ b/src/brain/online_greeting.py
@@ -104,7 +104,7 @@ def render_greeting_text(ctx: GreetingContext) -> str:
             parts.append("Note: RAM under load.")
     else:
         if is_de:
-            parts.append("Alles bereit.")
+            parts.append("Alle Systeme nominal.")
         else:
             parts.append("All systems nominal.")
 


### PR DESCRIPTION
Two-line tweak: persona.default_language: "de" + DE closing phrase aligned with English "All systems nominal". Smoke output: "Bin online, Sir. 3 ungelesene Mails. 2 Termine heute. Alle Systeme nominal."