### PR TITLE
fix(voice-pipeline): drift batch 3 — distinct follow_up state + filler-channel guards

### DIFF
--- a/frontend/src/core/audio/useAudioEngine.ts
+++ b/frontend/src/core/audio/useAudioEngine.ts
@@ -156,15 +156,25 @@ export function useAudioEngine(
 
         if (prev === orbState) return;
 
-        if (prev !== null) {
+        // state_change fires on every real transition except:
+        //   - initial mount (prev === null)
+        //   - entering follow_up: it's a soft, continuation state — no jarring
+        //     state-change cue; the ambient loop resuming provides the implicit signal.
+        if (prev !== null && orbState !== 'follow_up') {
             engine.playOneShot('state_change');
         }
 
         if (prev === 'listening') {
             engine.setDucking(false);
             engine.playOneShot('mic_close');
+        } else if (prev === 'follow_up') {
+            // follow_up exit: ambient loop stays alive for the next entry branch to handle.
+            // No ducking was active, no scan was running — nothing to clean up here.
         } else if (prev === 'speaking') {
             engine.setDucking(false);
+            // Barge-in only when the user literally interrupted: listening arrives while
+            // audio was playing. A follow_up transition means audio finished normally —
+            // play speech_end so the end-of-speech cue fires reliably.
             const isBargeIn = orbState === 'listening';
             if (isBargeIn) {
                 engine.playOneShot('barge_in');
@@ -180,10 +190,19 @@ export function useAudioEngine(
             engine.stop('scan');
         }
 
-        if (orbState === 'idle' || orbState === 'follow_up') {
+        if (orbState === 'idle') {
             stopIdleLoops();
             engine.play('ambient');
             startIdleTimer();
+        } else if (orbState === 'follow_up') {
+            // Softer alert-but-relaxed listening window: ambient resumes, scan stops,
+            // no idle-pulse timer (we're still actively in a conversation turn),
+            // no mic_open SFX (mic is already open from the previous listening state),
+            // no state_change cue (suppressed above — ambient loop is the implicit signal).
+            stopIdleLoops();
+            engine.stop('scan');
+            engine.setDucking(false);
+            engine.play('ambient');
         } else if (orbState === 'listening') {
             stopIdleLoops();
             engine.setDucking(true);
@@ -236,7 +255,9 @@ export function useAudioEngine(
     }, [connected]);
 
     useEffect(() => {
-        if ((orbState === 'idle' || orbState === 'follow_up') && idleTimerRef.current === null) {
+        // Heartbeat is an idle-only ambient — don't play it during follow_up
+        // (which is an active conversation window, not a true resting state).
+        if (orbState === 'idle' && idleTimerRef.current === null) {
             if (heartbeatEnabled) {
                 engineRef.current.play('heartbeat');
             } else {

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -1650,6 +1650,7 @@ async def _broadcast_from_cache(
     language: str,
     log_label: str,
     stat_key: str | None = None,
+    channel: str | None = None,
 ) -> None:
     """Pick a random pre-cached MP3 from ``cache`` and broadcast it.
 
@@ -1660,6 +1661,9 @@ async def _broadcast_from_cache(
         stat_key: Prefix for ``_phrase_cache_stats`` counters
             (e.g. ``"filler"`` increments ``filler_hits`` / ``filler_misses``).
             When ``None`` no stats are updated.
+        channel: Optional channel tag forwarded to :func:`broadcast_audio`.
+            Pass ``"filler"`` for filler/quick-ack clips so the frontend can
+            avoid forcing the orb into ``speaking`` state for non-speech audio.
     """
     import random
 
@@ -1689,12 +1693,14 @@ async def _broadcast_from_cache(
         _phrase_cache_stats[f"{stat_key}_hits"] = (
             _phrase_cache_stats.get(f"{stat_key}_hits", 0) + 1
         )
-    await broadcast_audio(audio_b64, text)
+    await broadcast_audio(audio_b64, text, channel=channel)
 
 
 async def _broadcast_quick_ack_filler(language: str) -> None:
     """Broadcast a random pre-cached filler MP3 — plays while LLM is running."""
-    await _broadcast_from_cache(_filler_cache, language, "Filler", stat_key="filler")
+    await _broadcast_from_cache(
+        _filler_cache, language, "Filler", stat_key="filler", channel="filler"
+    )
 
 
 async def _maybe_play_backchannel(
@@ -1835,9 +1841,10 @@ async def _arm_follow_up_window(ws: web.WebSocketResponse) -> None:
     window = _conversation_mode.window_seconds
     logger.info(f"Follow-up window armed for {window:.1f}s")
     await broadcast_conversation_mode(active=True, seconds_remaining=window)
-    # Keep broadcasting "listening" so the frontend orb stays lit during
-    # the follow-up window (a new wake word is not required inside it).
-    await broadcast_state("listening")
+    # Broadcast "follow_up" so the frontend orb can render conversation-mode
+    # distinctly from a fresh "listening" state.  The barge-in path keeps its
+    # own broadcast_state("listening") call — that one is intentionally unchanged.
+    await broadcast_state("follow_up")
 
     timer = asyncio.create_task(_follow_up_expiry_task(conn_id, window))
     state["follow_up_timer_task"] = timer
@@ -2089,7 +2096,9 @@ async def _run_voice_pipeline_body(
     # filler_*.mp3 — same delivery path, better UX signal.
     if _quick_ack_enabled and _quick_ack_generator is not None and _ack_cache:
         if _quick_ack_generator.should_ack(result.text):
-            await _broadcast_from_cache(_ack_cache, result.language, "QuickAck", stat_key="ack")
+            await _broadcast_from_cache(
+                _ack_cache, result.language, "QuickAck", stat_key="ack", channel="filler"
+            )
         else:
             await _broadcast_quick_ack_filler(result.language)
     else:


### PR DESCRIPTION
Surgical drift fixes from the E2E audit. (1) Filler/ack audio tagged `channel="filler"` so frontend doesn't force orb→speaking during LLM thinking. (2) `_arm_follow_up_window` broadcasts `follow_up` (not `listening`) so conversation-mode is visually + audibly distinct. (3) `state_change` SFX skipped on follow_up entry — softer feel. (4) `scan` loop stopped on follow_up entry. Tests 584/584, build clean.