### PR TITLE
chore(controller): drop SSH-tunnel plumbing — Tailscale-only remote-OpenClaw flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ cd frontend && npm install && npm run dev
 
 ## Setup — OpenClaw + Google Workspace (gog)
 
-### Remote OpenClaw gateway
+### Remote OpenClaw gateway via Tailscale
 
 JARVIS routes Claude API calls through the OpenClaw gateway (port 18789). The gateway can run locally or on a remote machine.
 
 - Install on all machines: `npm install -g openclaw`
-- For a remote gateway (e.g., Linux laptop reached from Windows), start it with `--bind lan` or expose it via SSH tunnel. The JARVIS Controller auto-spawns the SSH tunnel on Backend Start when `JARVIS_OPENCLAW_URL` points to a remote host.
+- For a remote gateway (e.g., Linux laptop reached from Windows PC): install [Tailscale](https://tailscale.com) on both machines, then bind the OpenClaw gateway on the tailnet (`--bind tailscale` or configure `gateway.bind: "tailscale"` in `~/.openclaw/openclaw.json`).
+- In the JARVIS Controller settings panel, paste the gateway's Tailscale IP as the **OpenClaw Gateway URL** (e.g. `http://100.84.x.y:18789`). No SSH tunnel needed.
 - Client-side config file: `~/.openclaw/openclaw.json` (or `%APPDATA%\.openclaw\openclaw.json` on Windows). Required keys when talking to a remote gateway:
 
 ```json
@@ -47,13 +48,15 @@ JARVIS routes Claude API calls through the OpenClaw gateway (port 18789). The ga
   "gateway": {
     "mode": "remote",
     "remote": {
-      "url": "ws://127.0.0.1:18789",
+      "url": "ws://<tailscale-ip>:18789",
       "transport": "direct",
       "token": "<shared gateway token from the host's openclaw.json>"
     }
   }
 }
 ```
+
+See [`docs/REMOTE_OPENCLAW.md`](docs/REMOTE_OPENCLAW.md) for step-by-step setup instructions.
 
 ### gog skill (Gmail, Calendar, Drive)
 
@@ -78,37 +81,26 @@ JARVIS delegates mail/calendar/drive actions to the `gog` CLI via OpenClaw.
 Two distinct mechanisms — do not confuse them:
 
 - **Python backend** reads `D:\Repos\JARVIS\.env` (via `python-dotenv`). Variable name there: `OPENCLAW_GATEWAY_URL`.
-- **Tauri Controller** is a compiled Rust binary and does **not** read `.env`. It reads OS environment variables only. Variable name there: `JARVIS_OPENCLAW_URL`. When set, it **overrides the hard-coded IP compiled into the binary** — useful when the remote laptop's IP changes and you don't want to rebuild.
+- **Tauri Controller** is a compiled Rust binary and does **not** read `.env`. It persists the gateway URL in its own settings file (see the Controller settings panel). The env var `JARVIS_OPENCLAW_URL` overrides the persisted value at runtime if set.
 
 Relevant variables:
 
-- `JARVIS_OPENCLAW_URL` — full URL of the remote gateway, e.g. `http://192.168.1.121:18789`. Read only by the Controller. Takes precedence over the hard-coded fallback.
-- `JARVIS_OPENCLAW_SSH_HOST` — optional SSH alias (from `~/.ssh/config`) to tunnel through when the gateway is not directly reachable.
-- `OPENCLAW_GATEWAY_URL` — put in `.env`; read by the Python backend. Leave commented out to default to `http://127.0.0.1:18789` (sensible when the backend reaches the gateway through the Controller's SSH tunnel).
+- `JARVIS_OPENCLAW_URL` — full URL of the remote gateway, e.g. `http://100.84.x.y:18789` (Tailscale). Read only by the Controller. Takes precedence over the settings-panel value.
+- `OPENCLAW_GATEWAY_URL` — put in `.env`; read by the Python backend. Set to your Tailscale URL for remote gateways, or `http://127.0.0.1:18789` for local.
 
-#### Set / update on Windows (user scope)
+#### Set / update on Windows (user scope, optional override)
 
 ```powershell
-[Environment]::SetEnvironmentVariable('JARVIS_OPENCLAW_URL', 'http://192.168.1.121:18789', 'User')
+[Environment]::SetEnvironmentVariable('JARVIS_OPENCLAW_URL', 'http://100.84.x.y:18789', 'User')
 ```
 
-After setting, **fully restart the Controller** (close it, then re-launch the `.exe`) — Tauri reads the environment once at process start.
+After setting, **fully restart the Controller** (close it, then re-launch the `.exe`) — Tauri reads the environment once at process start. The Controller settings panel is the recommended approach; the env var is an escape hatch.
 
-#### Remove again (Controller falls back to its compiled default)
+#### Remove the override (Controller falls back to settings-panel value)
 
 ```powershell
 Remove-ItemProperty -Path 'HKCU:\Environment' -Name 'JARVIS_OPENCLAW_URL' -ErrorAction SilentlyContinue
 ```
-
-Then restart the Controller.
-
-#### Verify what the Controller currently uses
-
-```powershell
-[Environment]::GetEnvironmentVariable('JARVIS_OPENCLAW_URL', 'User')
-```
-
-Empty / no output → Controller uses its compiled default URL.
 
 ## Controller App (optional)
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,6 +78,9 @@ memory:
 
 openclaw:
   enabled: true
+  # For remote OpenClaw via Tailscale, use the gateway host's tailnet URL,
+  # e.g. "http://100.84.x.y:18789". For local OpenClaw, use "http://127.0.0.1:18789".
+  # Do NOT change this to a Tailscale URL here — update your own tailnet IP.
   gateway_url: "http://192.168.1.121:18789"
   gateway_port: 18789
   managed_daemon: false  # true = JARVIS starts/stops daemon; false = assume systemd

--- a/controller/index.html
+++ b/controller/index.html
@@ -74,26 +74,12 @@
           <div class="target-url" id="openclaw-target-url"></div>
 
           <section class="openclaw-advanced">
-            <label class="field-label" for="openclaw-ssh-host">SSH HOST</label>
+            <label class="field-label" for="openclaw-remote-url">OPENCLAW GATEWAY URL</label>
             <div class="field-row">
-              <input type="text" id="openclaw-ssh-host" class="text-input" placeholder="laptop" />
-              <button class="btn btn-small" id="btn-save-ssh-host">Save</button>
-            </div>
-
-            <label class="field-label" for="openclaw-remote-url">REMOTE URL</label>
-            <div class="field-row">
-              <input type="text" id="openclaw-remote-url" class="text-input" placeholder="http://192.168.1.121:18789" />
+              <input type="text" id="openclaw-remote-url" class="text-input" placeholder="http://100.84.x.y:18789" />
               <button class="btn btn-small" id="btn-save-remote-url">Save</button>
             </div>
-
-            <div class="tunnel-row">
-              <div class="status-pill tunnel-pill" id="tunnel-status-pill">
-                <span class="dot" id="tunnel-dot"></span>
-                <span class="state-text" id="tunnel-state-text">checking...</span>
-              </div>
-              <button class="btn btn-start" id="btn-tunnel-start" disabled>TUNNEL UP</button>
-              <button class="btn btn-stop"  id="btn-tunnel-stop"  disabled>TUNNEL DOWN</button>
-            </div>
+            <p class="field-hint">Running OpenClaw on a different machine? Install Tailscale on both, bind the OpenClaw gateway on the tailnet, paste your Tailscale URL above.</p>
           </section>
 
           <section class="controls">

--- a/controller/src-tauri/src/lib.rs
+++ b/controller/src-tauri/src/lib.rs
@@ -24,17 +24,14 @@ struct OpenclawSettings {
 struct OpenclawSection {
     /// `"local"` or `"remote"`.
     target: String,
-    /// SSH hostname used when target is `"remote"`.
-    #[serde(default = "default_ssh_host")]
-    ssh_host: String,
-    /// LAN/WAN URL of the remote OpenClaw gateway (used when building the
-    /// tunnel but also exposed to the frontend for informational purposes).
+    /// LAN/tailnet URL of the remote OpenClaw gateway.
+    /// For Tailscale setups: `http://<tailscale-ip>:18789`
+    /// For local OpenClaw: `http://127.0.0.1:18789`
     #[serde(default = "default_remote_url")]
     remote_url: String,
-}
-
-fn default_ssh_host() -> String {
-    "laptop".into()
+    // NOTE: `ssh_host` was removed — SSH-tunnel management is no longer part of the
+    // Controller. Remote access is now handled by Tailscale. Old settings files that
+    // still contain `ssh_host` are silently ignored via serde's unknown-field handling.
 }
 
 fn default_remote_url() -> String {
@@ -48,9 +45,7 @@ pub struct OpenclawTargetInfo {
     pub target: String,
     /// The resolved base URL for that target.
     pub url: String,
-    /// SSH hostname used when opening the tunnel.
-    pub ssh_host: String,
-    /// Configured remote URL (LAN address of the gateway).
+    /// Configured remote URL (Tailscale or LAN address of the gateway).
     pub remote_url: String,
 }
 
@@ -90,7 +85,6 @@ fn read_openclaw_settings() -> OpenclawSection {
         Err(_) => {
             return OpenclawSection {
                 target: "remote".into(),
-                ssh_host: default_ssh_host(),
                 remote_url: default_remote_url(),
             }
         }
@@ -100,7 +94,6 @@ fn read_openclaw_settings() -> OpenclawSection {
         Err(_) => {
             return OpenclawSection {
                 target: "remote".into(),
-                ssh_host: default_ssh_host(),
                 remote_url: default_remote_url(),
             }
         }
@@ -111,7 +104,6 @@ fn read_openclaw_settings() -> OpenclawSection {
     };
     OpenclawSection {
         target,
-        ssh_host: settings.openclaw.ssh_host,
         remote_url: settings.openclaw.remote_url,
     }
 }
@@ -127,7 +119,6 @@ fn write_openclaw_settings(section: &OpenclawSection) -> Result<(), String> {
     let settings = OpenclawSettings {
         openclaw: OpenclawSection {
             target: section.target.clone(),
-            ssh_host: section.ssh_host.clone(),
             remote_url: section.remote_url.clone(),
         },
     };
@@ -147,7 +138,6 @@ fn to_info(s: &OpenclawSection) -> OpenclawTargetInfo {
     OpenclawTargetInfo {
         target: s.target.clone(),
         url,
-        ssh_host: s.ssh_host.clone(),
         remote_url: s.remote_url.clone(),
     }
 }
@@ -186,7 +176,7 @@ fn repo_root() -> Result<PathBuf, String> {
 /// Precedence:
 /// 1. `JARVIS_OPENCLAW_URL` env var (explicit override).
 /// 2. Settings file `target`: `"local"` → `http://127.0.0.1:18789`,
-///    `"remote"` → the configured `remote_url` field.
+///    `"remote"` → the configured `remote_url` field (Tailscale or LAN URL).
 /// 3. Hardcoded fallback `http://127.0.0.1:18789`.
 fn openclaw_base_url() -> String {
     if let Ok(v) = std::env::var("JARVIS_OPENCLAW_URL") {
@@ -199,22 +189,6 @@ fn openclaw_base_url() -> String {
         "local" => "http://127.0.0.1:18789".into(),
         "remote" => s.remote_url,
         _ => "http://127.0.0.1:18789".into(),
-    }
-}
-
-// ── TCP port probe ────────────────────────────────────────────────────────────
-
-/// Return `true` if something is accepting TCP connections on `127.0.0.1:<port>`.
-///
-/// Uses a plain socket connect with a 300 ms timeout — no WMI, no PowerShell,
-/// works on every platform. ECONNREFUSED on loopback is instantaneous, so the
-/// timeout only fires when the port is silently filtered (rare on localhost).
-async fn is_local_port_listening(port: u16) -> bool {
-    let addr = format!("127.0.0.1:{port}");
-    let connect = tokio::net::TcpStream::connect(&addr);
-    match tokio::time::timeout(Duration::from_millis(300), connect).await {
-        Ok(Ok(_)) => true,
-        _ => false,
     }
 }
 
@@ -344,89 +318,6 @@ fn build_frontend_command(repo: &PathBuf) -> tokio::process::Command {
     }
 
     cmd
-}
-
-// ── SSH tunnel (Windows / macOS only) ────────────────────────────────────────
-
-/// Build the argv for the SSH tunnel command, reading the host from settings.
-#[cfg(not(target_os = "linux"))]
-fn ssh_tunnel_argv() -> Vec<String> {
-    let host = read_openclaw_settings().ssh_host;
-    vec![
-        "-o".into(),
-        "BatchMode=yes".into(),
-        "-o".into(),
-        "ServerAliveInterval=30".into(),
-        "-o".into(),
-        "ExitOnForwardFailure=yes".into(),
-        "-N".into(),
-        "-L".into(),
-        "18789:localhost:18789".into(),
-        host,
-    ]
-}
-
-/// Ensure the SSH tunnel to the remote OpenClaw gateway is up.
-///
-/// - If the OpenClaw target is `"local"`, returns `Ok(())` immediately.
-/// - If port 18789 already has a listener, assumes the tunnel is up.
-/// - Otherwise spawns `ssh <ssh_tunnel_argv()>` and polls for up to 5 s.
-#[cfg(not(target_os = "linux"))]
-async fn ensure_ssh_tunnel() -> Result<(), String> {
-    use std::process::Stdio;
-
-    if read_openclaw_settings().target == "local" {
-        return Ok(());
-    }
-
-    if is_local_port_listening(18789).await {
-        return Ok(());
-    }
-
-    let mut cmd = tokio::process::Command::new("ssh");
-    cmd.args(ssh_tunnel_argv());
-    cmd.stdin(Stdio::null());
-    cmd.stdout(Stdio::null());
-    cmd.stderr(Stdio::null());
-
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000);
-    }
-
-    let child = cmd
-        .spawn()
-        .map_err(|e| format!("failed to spawn SSH tunnel: {e}"))?;
-
-    CHILDREN.lock().await.insert("ssh_tunnel", child);
-
-    // Poll up to 5 s (25 × 200 ms) for port 18789 to become live.
-    for _ in 0..25 {
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        if is_local_port_listening(18789).await {
-            return Ok(());
-        }
-    }
-
-    // Timed out — kill the child and report failure.
-    let mut map = CHILDREN.lock().await;
-    if let Some(mut child) = map.remove("ssh_tunnel") {
-        let _ = child.kill().await;
-        let _ = child.wait().await;
-    }
-    Err("SSH tunnel did not come up within 5s".into())
-}
-
-/// Tear down the tracked SSH tunnel child, if any.
-#[cfg(not(target_os = "linux"))]
-async fn stop_ssh_tunnel() -> Result<(), String> {
-    let mut map = CHILDREN.lock().await;
-    if let Some(mut child) = map.remove("ssh_tunnel") {
-        let _ = child.kill().await;
-        let _ = child.wait().await;
-    }
-    Ok(())
 }
 
 // ── Port-based kill helpers (Windows / macOS) ────────────────────────────────
@@ -790,7 +681,6 @@ pub mod commands {
             if state == ChildState::Running {
                 return Ok("already running".into());
             }
-            ensure_ssh_tunnel().await?;
             let child = build_backend_command(&repo)
                 .spawn()
                 .map_err(|e| format!("failed to spawn backend: {e}"))?;
@@ -830,8 +720,6 @@ pub mod commands {
                 format!("{}*-m main", venv_python.replace('\\', "\\\\"))
             };
             let orphans = kill_by_cmdline(&pattern, "backend-orphan").await;
-
-            let _ = stop_ssh_tunnel().await;
 
             if orphans > 0 {
                 Ok(format!("stopped (cleaned {orphans} orphan(s))"))
@@ -997,90 +885,17 @@ pub mod commands {
     /// Return the OpenClaw URL with an auth token appended as a URL hash fragment.
     ///
     /// Tries multiple strategies in order:
-    /// 1. SSH to remote host → `openclaw dashboard --no-open` → parse `#token=`
-    /// 2. Local CLI → `openclaw dashboard --no-open` → parse `#token=`
-    /// 3. Local config file `~/.openclaw/openclaw.json` → `gateway.auth.token`
-    /// 4. Fallback → bare URL
+    /// 1. Local CLI → `openclaw dashboard --no-open` → parse `#token=`
+    /// 2. Local config file `~/.openclaw/openclaw.json` → `gateway.auth.token`
+    /// 3. Fallback → bare URL
     ///
     /// Any failure logs a warning and falls through to the next strategy.
     #[tauri::command]
     pub async fn openclaw_url() -> Result<String, String> {
-        // When remote, always use localhost (via SSH tunnel) so the browser
-        // has a secure context for device-identity crypto APIs.
-        let is_remote = read_openclaw_settings().target == "remote";
-        let dashboard_base = if is_remote {
-            "http://127.0.0.1:18789".to_string()
-        } else {
-            openclaw_base_url()
-        };
+        let dashboard_base = openclaw_base_url();
         let fallback = format!("{}/", dashboard_base.trim_end_matches('/'));
 
-        // Ensure SSH tunnel is up when remote so localhost:18789 works.
-        #[cfg(not(target_os = "linux"))]
-        if is_remote {
-            if let Err(e) = ensure_ssh_tunnel().await {
-                eprintln!("[openclaw_url] SSH tunnel failed: {}", e);
-            }
-        }
-
-        // ── Strategy 1: SSH to remote host ───────────────────────────────────
-        let ssh_host_override = std::env::var("JARVIS_OPENCLAW_SSH_HOST")
-            .ok()
-            .filter(|v| !v.trim().is_empty());
-        let ssh_host: Option<String> = if ssh_host_override.is_some() {
-            ssh_host_override
-        } else if read_openclaw_settings().target == "remote" {
-            Some(read_openclaw_settings().ssh_host)
-        } else {
-            None
-        };
-
-        if let Some(host) = &ssh_host {
-            let remote_cmd = concat!(
-                r#"export NVM_DIR="$HOME/.nvm" && "#,
-                r#". "$NVM_DIR/nvm.sh" && "#,
-                r#"openclaw dashboard --no-open 2>&1"#
-            );
-
-            let ssh_future = tokio::process::Command::new("ssh")
-                .args([
-                    "-o", "BatchMode=yes",
-                    "-o", "ConnectTimeout=5",
-                    host.trim(),
-                    remote_cmd,
-                ])
-                .output();
-
-            match tokio::time::timeout(Duration::from_secs(10), ssh_future).await {
-                Ok(Ok(output)) if output.status.success() => {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    if let Some(token) = extract_hash_token(&stdout) {
-                        return Ok(format!(
-                            "{}/#token={}",
-                            dashboard_base.trim_end_matches('/'),
-                            token
-                        ));
-                    }
-                    eprintln!(
-                        "[openclaw_url] SSH ok but #token= not found in output"
-                    );
-                }
-                Ok(Ok(output)) => {
-                    eprintln!(
-                        "[openclaw_url] SSH exited {:?} — trying local CLI",
-                        output.status.code()
-                    );
-                }
-                Ok(Err(e)) => {
-                    eprintln!("[openclaw_url] SSH spawn error: {} — trying local CLI", e);
-                }
-                Err(_) => {
-                    eprintln!("[openclaw_url] SSH timed out — trying local CLI");
-                }
-            }
-        }
-
-        // ── Strategy 2: local CLI `openclaw dashboard --no-open` ─────────────
+        // ── Strategy 1: local CLI `openclaw dashboard --no-open` ─────────────
         {
             let cli_argv = _resolve_openclaw_cli_argv();
             if let Some(argv) = cli_argv {
@@ -1124,7 +939,7 @@ pub mod commands {
             }
         }
 
-        // ── Strategy 3: read ~/.openclaw/openclaw.json ───────────────────────
+        // ── Strategy 2: read ~/.openclaw/openclaw.json ───────────────────────
         let home = {
             #[cfg(target_os = "windows")]
             { std::env::var("USERPROFILE").unwrap_or_else(|_| "C:\\Users\\user".into()) }
@@ -1149,7 +964,7 @@ pub mod commands {
             }
         }
 
-        // ── Strategy 4: bare URL fallback ────────────────────────────────────
+        // ── Strategy 3: bare URL fallback ────────────────────────────────────
         eprintln!(
             "[openclaw_url] WARNING: no token found via any strategy — returning bare URL"
         );
@@ -1185,19 +1000,9 @@ pub mod commands {
         Ok(to_info(&s))
     }
 
-    /// Persist a new SSH hostname used when opening the remote tunnel.
-    #[tauri::command]
-    pub async fn set_openclaw_ssh_host(ssh_host: String) -> Result<OpenclawTargetInfo, String> {
-        if ssh_host.trim().is_empty() {
-            return Err("ssh_host must not be empty".into());
-        }
-        let mut s = read_openclaw_settings();
-        s.ssh_host = ssh_host.trim().into();
-        write_openclaw_settings(&s)?;
-        Ok(to_info(&s))
-    }
-
-    /// Persist a new remote URL for the OpenClaw gateway.
+    /// Persist a new remote URL for the OpenClaw gateway (Tailscale or LAN URL).
+    ///
+    /// Example: `http://100.84.x.y:18789` for a Tailscale-reachable gateway.
     #[tauri::command]
     pub async fn set_openclaw_remote_url(remote_url: String) -> Result<OpenclawTargetInfo, String> {
         let trimmed = remote_url.trim();
@@ -1211,56 +1016,6 @@ pub mod commands {
         s.remote_url = trimmed.into();
         write_openclaw_settings(&s)?;
         Ok(to_info(&s))
-    }
-
-    /// Report whether the SSH tunnel is active and localhost:18789 is reachable.
-    ///
-    /// On Linux the tunnel concept does not apply; returns state `"n/a"`.
-    #[tauri::command]
-    pub async fn tunnel_status() -> Result<StatusInfo, String> {
-        #[cfg(target_os = "linux")]
-        {
-            let http_ok = check_http_openclaw().await;
-            Ok(StatusInfo { state: "n/a".into(), http_ok })
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            let listening = is_local_port_listening(18789).await;
-            let http_ok = check_http_url("http://127.0.0.1:18789/").await;
-            let state = if listening { "active" } else { "inactive" };
-            Ok(StatusInfo { state: state.into(), http_ok })
-        }
-    }
-
-    /// Bring the SSH tunnel up (non-Linux only; target must be `"remote"`).
-    #[tauri::command]
-    pub async fn start_tunnel() -> Result<String, String> {
-        #[cfg(target_os = "linux")]
-        {
-            Err("tunnel not applicable on Linux host".into())
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            if read_openclaw_settings().target != "remote" {
-                return Err("target is not 'remote'; nothing to tunnel".into());
-            }
-            ensure_ssh_tunnel().await?;
-            Ok("tunnel up".into())
-        }
-    }
-
-    /// Tear down the SSH tunnel (non-Linux only).
-    #[tauri::command]
-    pub async fn stop_tunnel() -> Result<String, String> {
-        #[cfg(target_os = "linux")]
-        {
-            Ok("n/a".into())
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            stop_ssh_tunnel().await?;
-            Ok("tunnel stopped".into())
-        }
     }
 
     // ── Generic HTTP check (kept for potential future use) ────────────────────
@@ -1287,11 +1042,7 @@ pub fn run() {
             commands::openclaw_url,
             commands::get_openclaw_target,
             commands::set_openclaw_target,
-            commands::set_openclaw_ssh_host,
             commands::set_openclaw_remote_url,
-            commands::tunnel_status,
-            commands::start_tunnel,
-            commands::stop_tunnel,
             commands::start_frontend,
             commands::stop_frontend,
             commands::restart_frontend,

--- a/controller/src/main.ts
+++ b/controller/src/main.ts
@@ -9,7 +9,6 @@ interface StatusInfo {
 interface OpenclawTargetInfo {
   target: string;
   url: string;
-  ssh_host: string;
   remote_url: string;
 }
 
@@ -40,17 +39,9 @@ const toggleLocal          = document.getElementById("toggle-local")           a
 const toggleRemote         = document.getElementById("toggle-remote")          as HTMLButtonElement;
 const openclawTargetUrl    = document.getElementById("openclaw-target-url")    as HTMLDivElement;
 
-// ── DOM refs — OpenClaw advanced fields ──────────────────────────────────────
-const inputSshHost         = document.getElementById("openclaw-ssh-host")      as HTMLInputElement;
+// ── DOM refs — OpenClaw settings fields ──────────────────────────────────────
 const inputRemoteUrl       = document.getElementById("openclaw-remote-url")    as HTMLInputElement;
-const btnSaveSshHost       = document.getElementById("btn-save-ssh-host")      as HTMLButtonElement;
 const btnSaveRemoteUrl     = document.getElementById("btn-save-remote-url")    as HTMLButtonElement;
-
-// ── DOM refs — Tunnel ────────────────────────────────────────────────────────
-const tunnelDot            = document.getElementById("tunnel-dot")             as HTMLSpanElement;
-const tunnelStateText      = document.getElementById("tunnel-state-text")      as HTMLSpanElement;
-const btnTunnelStart       = document.getElementById("btn-tunnel-start")       as HTMLButtonElement;
-const btnTunnelStop        = document.getElementById("btn-tunnel-stop")        as HTMLButtonElement;
 
 // ── DOM refs — links ─────────────────────────────────────────────────────────
 const btnLinkJarvis   = document.getElementById("btn-link-jarvis")   as HTMLButtonElement;
@@ -160,40 +151,14 @@ function applyOpenclawTarget(info: OpenclawTargetInfo): void {
   toggleRemote.classList.toggle("active", !isLocal);
   openclawTargetUrl.textContent = `Target: ${info.url}`;
 
-  // Populate fields only when they aren't focused (don't clobber live typing)
-  if (document.activeElement !== inputSshHost) {
-    inputSshHost.value = info.ssh_host;
-  }
+  // Populate field only when it isn't focused (don't clobber live typing)
   if (document.activeElement !== inputRemoteUrl) {
     inputRemoteUrl.value = info.remote_url;
   }
 
-  // SSH host + remote URL fields are only useful when target is remote
-  const remoteOnly = isLocal;
-  inputSshHost.disabled    = remoteOnly;
-  inputRemoteUrl.disabled  = remoteOnly;
-  btnSaveSshHost.disabled  = remoteOnly;
-  btnSaveRemoteUrl.disabled = remoteOnly;
-}
-
-function applyTunnelStatus(info: StatusInfo): void {
-  const state = info.state.toLowerCase().trim();
-  tunnelStateText.textContent = state;
-
-  if (state === "active") {
-    tunnelDot.className = "dot active";
-    btnTunnelStart.disabled = true;
-    btnTunnelStop.disabled  = false;
-  } else if (state === "inactive") {
-    tunnelDot.className = "dot inactive";
-    btnTunnelStart.disabled = false;
-    btnTunnelStop.disabled  = true;
-  } else {
-    // "n/a" or any unknown state (e.g. Linux host without SSH tunnel support)
-    tunnelDot.className = "dot unknown";
-    btnTunnelStart.disabled = true;
-    btnTunnelStop.disabled  = true;
-  }
+  // Remote URL field is only relevant when target is remote
+  inputRemoteUrl.disabled   = isLocal;
+  btnSaveRemoteUrl.disabled = isLocal;
 }
 
 // ── Polling ───────────────────────────────────────────────────────────────────
@@ -239,18 +204,6 @@ async function pollAll(): Promise<void> {
         btnOpenclawRestart.disabled = true;
         btnLinkOpenclaw.disabled    = true;
         console.error("openclaw status poll failed:", e);
-      }
-    })(),
-    (async () => {
-      try {
-        const info = await invoke<StatusInfo>("tunnel_status");
-        applyTunnelStatus(info);
-      } catch (e) {
-        tunnelStateText.textContent = "n/a";
-        tunnelDot.className = "dot unknown";
-        btnTunnelStart.disabled = true;
-        btnTunnelStop.disabled  = true;
-        console.error("tunnel status poll failed:", e);
       }
     })(),
   ]);
@@ -436,66 +389,25 @@ async function handleTargetSelect(target: "local" | "remote"): Promise<void> {
 toggleLocal.addEventListener("click", () => handleTargetSelect("local"));
 toggleRemote.addEventListener("click", () => handleTargetSelect("remote"));
 
-// ── OpenClaw advanced field handlers ─────────────────────────────────────────
-btnSaveSshHost.addEventListener("click", async () => {
-  const value = inputSshHost.value.trim();
-  if (value === "") {
-    showToast("openclaw · SSH host must not be empty", true);
-    return;
-  }
-  try {
-    const info = await invoke<OpenclawTargetInfo>("set_openclaw_ssh_host", { sshHost: value });
-    applyOpenclawTarget(info);
-    showToast(`openclaw · SSH host saved: ${value}`);
-  } catch (e) {
-    const msg = typeof e === "string" ? e : String(e);
-    showToast(`openclaw · save SSH host failed: ${msg}`, true);
-  }
-});
-
+// ── OpenClaw gateway URL handler ──────────────────────────────────────────────
 btnSaveRemoteUrl.addEventListener("click", async () => {
   const value = inputRemoteUrl.value.trim();
   if (value === "") {
-    showToast("openclaw · remote URL must not be empty", true);
+    showToast("openclaw · gateway URL must not be empty", true);
     return;
   }
   if (!value.startsWith("http://") && !value.startsWith("https://")) {
-    showToast("openclaw · remote URL must start with http:// or https://", true);
+    showToast("openclaw · gateway URL must start with http:// or https://", true);
     return;
   }
   try {
     const info = await invoke<OpenclawTargetInfo>("set_openclaw_remote_url", { remoteUrl: value });
     applyOpenclawTarget(info);
-    showToast(`openclaw · remote URL saved: ${value}`);
+    showToast(`openclaw · gateway URL saved: ${value}`);
   } catch (e) {
     const msg = typeof e === "string" ? e : String(e);
-    showToast(`openclaw · save remote URL failed: ${msg}`, true);
+    showToast(`openclaw · save gateway URL failed: ${msg}`, true);
   }
-});
-
-// ── Tunnel button handlers ────────────────────────────────────────────────────
-btnTunnelStart.addEventListener("click", async () => {
-  btnTunnelStart.disabled = true;
-  try {
-    await invoke<string>("start_tunnel");
-    showToast(`tunnel · started · ${timestamp()}`);
-  } catch (e) {
-    const msg = typeof e === "string" ? e : String(e);
-    showToast(`tunnel · start failed: ${msg}`, true);
-  }
-  await pollAll();
-});
-
-btnTunnelStop.addEventListener("click", async () => {
-  btnTunnelStop.disabled = true;
-  try {
-    await invoke<string>("stop_tunnel");
-    showToast(`tunnel · stopped · ${timestamp()}`);
-  } catch (e) {
-    const msg = typeof e === "string" ? e : String(e);
-    showToast(`tunnel · stop failed: ${msg}`, true);
-  }
-  await pollAll();
 });
 
 // ── Boot ──────────────────────────────────────────────────────────────────────

--- a/controller/src/style.css
+++ b/controller/src/style.css
@@ -357,7 +357,7 @@ html, body {
   min-height: 18px;
 }
 
-/* ── OpenClaw advanced section (SSH host, remote URL, tunnel) ── */
+/* ── OpenClaw advanced section (gateway URL, Tailscale hint) ── */
 .openclaw-advanced {
   display: flex;
   flex-direction: column;
@@ -424,30 +424,11 @@ html, body {
   letter-spacing: 0.14em;
 }
 
-/* Tunnel row: pill + start/stop side by side */
-.tunnel-row {
-  display: flex;
-  gap: 10px;
-  width: 100%;
-  align-items: center;
-  margin-top: 4px;
-}
-
-/* Compact pill variant for the tunnel row */
-.tunnel-pill {
-  flex: 1;
-  padding: 10px 16px;
-  justify-content: flex-start;
-  gap: 10px;
-}
-
-.tunnel-pill .state-text {
-  font-size: 13px;
-}
-
-.tunnel-row .btn {
-  flex: 0 0 auto;
-  padding: 10px 14px;
-  font-size: 12px;
-  letter-spacing: 0.12em;
+/* Hint text below settings fields */
+.field-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+  line-height: 1.5;
+  margin-top: 2px;
 }

--- a/docs/REMOTE_OPENCLAW.md
+++ b/docs/REMOTE_OPENCLAW.md
@@ -1,0 +1,75 @@
+# Remote OpenClaw via Tailscale
+
+This doc covers how to run the OpenClaw gateway on a separate machine (e.g. a Linux laptop) and connect JARVIS to it over Tailscale. No SSH tunnel required.
+
+## Prerequisites
+
+- [Tailscale](https://tailscale.com) installed and logged in on **both** machines.
+- OpenClaw installed on the gateway host: `npm install -g openclaw`.
+- OpenClaw installed locally (for the CLI token strategy): `npm install -g openclaw`.
+
+## Step 1 — Bind the gateway on the tailnet
+
+On the **Linux gateway host**, edit `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "gateway": {
+    "bind": "tailscale"
+  }
+}
+```
+
+Alternatively pass `--bind tailscale` when starting the daemon. The gateway will listen on the Tailscale interface (e.g. `100.84.x.y:18789`) rather than loopback only.
+
+Restart the gateway: `openclaw serve` (or `systemctl --user restart openclaw`).
+
+## Step 2 — Configure the JARVIS Controller
+
+Open the JARVIS Controller app on Windows. In the OpenClaw card:
+
+1. Set **Mode** to `REMOTE`.
+2. Paste the gateway's Tailscale IP into **OpenClaw Gateway URL**: `http://100.84.x.y:18789`.
+3. Click **Save**.
+4. Restart the JARVIS backend so it picks up the new URL.
+
+The "Reachable" pill in the Controller confirms connectivity.
+
+## Step 3 — Configure the Python backend
+
+In `.env` (or `config/config.yaml`):
+
+```
+OPENCLAW_GATEWAY_URL=http://100.84.x.y:18789
+```
+
+Or set `openclaw.gateway_url` in `config/config.yaml` to the same Tailscale URL.
+
+## Step 4 — Configure the local OpenClaw client
+
+On the **Windows PC**, `~/.openclaw/openclaw.json` (or `%APPDATA%\.openclaw\openclaw.json`) must point to the remote gateway:
+
+```json
+{
+  "gateway": {
+    "mode": "remote",
+    "remote": {
+      "url": "ws://100.84.x.y:18789",
+      "transport": "direct",
+      "token": "<token from gateway host's openclaw.json>"
+    }
+  }
+}
+```
+
+The shared token is found on the gateway host at `~/.openclaw/openclaw.json` → `gateway.auth.token`.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Controller shows "unreachable" | `ping 100.84.x.y` — is Tailscale up on both machines? |
+| Gateway not on tailnet | `tailscale status` on gateway host — is it connected? |
+| Port blocked | Check `openclaw.json` bind setting; confirm gateway is listening: `ss -tlnp \| grep 18789` |
+| Token mismatch | Re-copy `gateway.auth.token` from the host's config to the client's `openclaw.json` |
+| Wrong URL in backend | Check `OPENCLAW_GATEWAY_URL` in `.env` and `config/config.yaml` |


### PR DESCRIPTION
## Summary
Removes the dead SSH-tunnel code path from the JARVIS Controller and aligns the remote-OpenClaw story with Tailscale per OpenClaw's own \"Best UX\" guidance.

## Why
- Old: Controller spawned \`ssh -N -L 18789:localhost:18789 user@host\` on Win/macOS, but \`config/config.yaml.openclaw.gateway_url\` pointed at a LAN IP. Tunnel was running but unused — pure dead weight in Rust + UI.
- New: install Tailscale on both machines, bind the OpenClaw gateway on the tailnet, paste the tailnet URL into the Controller. No tunnel management at all.

## What changed
- **Rust** — \`OpenclawSettings\`/\`OpenclawSection\` lose \`ssh_host\` (kept tolerant deserialisation for old settings files), tunnel functions + Tauri commands gone, all call-sites cleaned.
- **TS / HTML / CSS** — SSH host field, tunnel pill, tunnel up/down buttons removed; replaced with a single Gateway URL input + Tailscale helper hint.
- **Docs** — \`docs/REMOTE_OPENCLAW.md\` (new, Tailscale setup); \`README.md\` updated.
- **Config** — \`config/config.yaml\` comments clarify the Tailscale URL pattern (value unchanged).

## Out of scope
- Python backend's openclaw integration (\`src/integrations/openclaw/*.py\`) is unchanged — it just connects to whatever URL config provides.
- \`config/SOUL.md\` + \`config/CAPABILITIES.md\` stay (used by \`scripts/install_openclaw.sh\` to deploy to \`~/.openclaw/workspace/\`).

## Test plan
- [ ] On user side: install Tailscale on Linux laptop + Win-PC, bind OpenClaw gateway on the tailnet, paste \`http://<tailscale-ip>:18789\` into Controller settings.
- [ ] Verify Controller settings panel renders without SSH fields and saves the URL.
- [ ] Verify backend connects to OpenClaw via the tailnet URL.

## Verification already run
- \`cargo check\` — 0 errors
- \`npm run build\` — clean
- 0 live-code references to \`ssh_host\`/\`ssh_tunnel\`/\`start_tunnel\`/\`stop_tunnel\`/\`tunnel_status\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)