### PR TITLE
fix(wake-word): prefer ai-edge-litert for NumPy 2 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ build/
 
 
 # Virtual environments
-.venv/
+.venv*/
 venv/
 env/
 ENV/

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cryptography
 
 # Audio / Voice pipeline
 faster-whisper
-openWakeWord
+openwakeword>=0.6.0
 onnxruntime
 # Wake-word inference: prefer ai-edge-litert (TFLite, better accuracy
 # per upstream); onnxruntime is kept as a fallback when neither tflite

--- a/src/audio/wake_word.py
+++ b/src/audio/wake_word.py
@@ -61,23 +61,25 @@ class WakeWordDetector:
 
                 logger.info("Loading OpenWakeWord model...")
 
-                # Determine inference framework: prefer tflite (better accuracy per
-                # upstream docs), fall back to onnx. On Windows, tflite-runtime is not
-                # on PyPI — but ai-edge-litert (Google's official TFLite runtime
-                # successor) is, and is API-compatible. Alias it so openwakeword's
-                # hard-coded `import tflite_runtime.interpreter` resolves.
+                # Determine inference framework: prefer ai-edge-litert (Google's
+                # official TFLite-runtime successor, NumPy-2-compatible — the
+                # legacy tflite-runtime 2.14 is pinned to NumPy 1.x ABI and
+                # crashes under NumPy 2.x). If ai-edge-litert is unavailable,
+                # fall back to native tflite_runtime; finally fall back to
+                # onnxruntime. The `sys.modules` aliasing satisfies
+                # openwakeword's hard-coded `import tflite_runtime.interpreter`.
                 framework = "onnx"
                 try:
-                    import tflite_runtime  # noqa: F401  # native Linux / RPi
+                    import ai_edge_litert
+                    import ai_edge_litert.interpreter as _ai_interp
+                    sys.modules["tflite_runtime"] = ai_edge_litert
+                    sys.modules["tflite_runtime.interpreter"] = _ai_interp
                     framework = "tflite"
+                    logger.debug("OpenWakeWord: tflite_runtime aliased to ai_edge_litert")
                 except ImportError:
                     try:
-                        import ai_edge_litert
-                        import ai_edge_litert.interpreter as _ai_interp
-                        sys.modules["tflite_runtime"] = ai_edge_litert
-                        sys.modules["tflite_runtime.interpreter"] = _ai_interp
+                        import tflite_runtime  # noqa: F401  # legacy native Linux / RPi
                         framework = "tflite"
-                        logger.debug("OpenWakeWord: tflite_runtime aliased to ai_edge_litert")
                     except ImportError:
                         pass  # keep framework="onnx"
                 logger.debug(f"OpenWakeWord inference framework: {framework}")


### PR DESCRIPTION
## Summary
- Reorders the OpenWakeWord framework-detection block so `ai_edge_litert` (Google's NumPy-2-compatible TFLite-runtime successor) is preferred, with the legacy `tflite_runtime` and `onnxruntime` as fallbacks. Avoids the NumPy 1.x ABI crash that the legacy runtime triggers on systems running NumPy 2.x.
- Normalizes the openwakeword pip name (`openWakeWord` → `openwakeword>=0.6.0`).
- Broadens `.gitignore` to `.venv*/` so secondary venvs (`.venv-test`, `.venv-rpi`, …) aren't accidentally committed.

## Test plan
- [ ] Backend boots without `numpy.core.multiarray failed to import` error on a NumPy-2 venv.
- [ ] `WakeWordDetector` startup log shows `OpenWakeWord inference framework: tflite` with the `tflite_runtime aliased to ai_edge_litert` debug line.
- [ ] Wake-word detection still triggers on "Jarvis" end-to-end.
- [ ] On a system without `ai_edge_litert` installed, fallback to legacy `tflite_runtime` (or `onnxruntime`) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)