### PR TITLE
chore(logging): route stdlib logging through loguru, kill shutdown traces

### DIFF
--- a/src/api/mcp_server.py
+++ b/src/api/mcp_server.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import socket
 import sys
 from collections.abc import Callable
@@ -29,6 +30,24 @@ from utils.device import load_device_identity, resolve_advertise_host
 from utils.logger import get_logger
 
 logger = get_logger("mcp_server")
+
+
+def _strip_rich_handler() -> None:
+    """Remove RichHandler instances that FastMCP.__init__ attaches.
+
+    The intercept is already installed via setup_logger; once Rich is
+    gone, all MCP log lines flow through loguru.
+    """
+    try:
+        from rich.logging import RichHandler  # noqa: PLC0415
+    except ImportError:
+        return  # Rich isn't installed — nothing to strip
+    root = logging.getLogger()
+    before = len(root.handlers)
+    root.handlers = [h for h in root.handlers if not isinstance(h, RichHandler)]
+    removed = before - len(root.handlers)
+    logger.debug(f"FastMCP RichHandler stripped (removed={removed})")
+
 
 # ---------------------------------------------------------------------------
 # Module-level singletons
@@ -185,6 +204,7 @@ async def start_mcp_server(config: dict[str, Any], device_slug: str) -> None:
             port=bind_port,
             log_level="WARNING",  # suppress uvicorn noise; loguru handles JARVIS logs
         )
+        _strip_rich_handler()
 
         # Register the device://info resource so the OpenClaw agent can query
         # identity on demand via the standard MCP resources/read protocol.
@@ -224,6 +244,7 @@ async def start_mcp_server(config: dict[str, Any], device_slug: str) -> None:
                     port=bind_port,
                     log_level="WARNING",
                 )
+                _strip_rich_handler()
                 _register_device_info_resource(_server, device_slug, bind_port)
                 for entry in _tool_registry.values():
                     _server.add_tool(

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,24 @@ async def _silent_tts(_text: str, _language: str) -> None:
     return None
 
 
+def _asyncio_exception_handler(
+    loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+) -> None:
+    """Print late-shutdown asyncio exceptions to stderr without touching stdlib logging.
+
+    Avoids re-entering the loguru/Rich/InterceptHandler stack during interpreter
+    teardown when sys.meta_path is None.
+    """
+    msg = context.get("message", "asyncio exception")
+    exc = context.get("exception")
+    try:
+        sys.stderr.write(f"[asyncio] {msg}\n")
+        if exc is not None:
+            sys.stderr.write(f"  exception: {exc!r}\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
 async def main() -> None:
     """Main entry point.
 
@@ -107,6 +125,7 @@ async def main() -> None:
         shutdown_event.set()
 
     loop = asyncio.get_event_loop()
+    loop.set_exception_handler(_asyncio_exception_handler)
     if sys.platform != "win32":
         loop.add_signal_handler(signal.SIGINT, _signal_handler)
         loop.add_signal_handler(signal.SIGTERM, _signal_handler)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -14,6 +14,7 @@ the broadcaster.
 """
 
 import asyncio
+import logging
 import sys
 import time
 from collections import deque
@@ -170,6 +171,52 @@ async def _drainer_task() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Stdlib → loguru bridge
+# ---------------------------------------------------------------------------
+
+
+class InterceptHandler(logging.Handler):
+    """Stdlib logging handler that re-emits records through loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            try:
+                level: str | int = logger.level(record.levelname).name
+            except ValueError:
+                level = record.levelno
+            frame, depth = sys._getframe(6), 6
+            while frame and frame.f_code.co_filename == logging.__file__:
+                frame = frame.f_back
+                depth += 1
+            logger.opt(depth=depth, exception=record.exc_info).log(
+                level, record.getMessage()
+            )
+        except Exception:  # noqa: BLE001
+            # Shutdown-safe fallback — loguru may already be torn down.
+            try:
+                sys.stderr.write(
+                    f"[InterceptHandler fallback] {record.levelname}: {record.getMessage()}\n"
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def install_stdlib_intercept(level: int = logging.DEBUG) -> None:
+    """Replace stdlib root-logger handlers with InterceptHandler.
+
+    Idempotent — safe to call multiple times.  Existing InterceptHandler
+    instances are preserved; non-Intercept handlers (RichHandler, default
+    StreamHandler, etc.) are removed so all stdlib logging flows through
+    loguru.
+    """
+    root = logging.getLogger()
+    root.handlers = [h for h in root.handlers if isinstance(h, InterceptHandler)]
+    if not any(isinstance(h, InterceptHandler) for h in root.handlers):
+        root.addHandler(InterceptHandler())
+    root.setLevel(level)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -224,6 +271,8 @@ def setup_logger(
         )
 
     logger.info(f"Logger initialized with level={level}")
+    stdlib_level = getattr(logging, level.upper(), logging.INFO)
+    install_stdlib_intercept(level=stdlib_level)
 
 
 def get_logger(name: str | None = None) -> Any:
@@ -247,4 +296,6 @@ __all__ = [
     "logger",
     "register_ws_broadcast",
     "get_log_buffer",
+    "InterceptHandler",
+    "install_stdlib_intercept",
 ]


### PR DESCRIPTION
## Summary
Closes #94. `FastMCP.__init__` unconditionally attaches a `RichHandler` to Python's stdlib root logger, which fires after `sys.meta_path` is cleared on shutdown and produces spurious `ImportError: sys.meta_path is None` traces that swallow real asyncio exceptions. This PR routes stdlib `logging` through loguru via an `InterceptHandler`, strips the `RichHandler` after `FastMCP(...)` construction, and installs a custom asyncio exception handler that bypasses stdlib logging entirely on shutdown.

## What's in
- `src/utils/logger.py` — new `InterceptHandler` class (canonical loguru pattern, `sys._getframe(6)` + walk while in `logging.__file__`) + `install_stdlib_intercept(level)` (idempotent). Called from `setup_logger` with the resolved stdlib level matching the app's loguru level. Shutdown-safe `emit` fallback writes to `sys.stderr` if loguru is torn down.
- `src/api/mcp_server.py` — new `_strip_rich_handler()` helper, called twice (after each `FastMCP(...)` construction — primary bind + Tailscale fallback).
- `src/main.py` — new `_asyncio_exception_handler` that prints late-shutdown asyncio exceptions to `sys.stderr` directly, never re-entering loguru/stdlib logging. Registered via `loop.set_exception_handler(...)`.

## Test plan (live-tested)
- [x] 3× cold-start + SIGTERM cycle → **zero `meta_path` matches** in stderr/log output across all runs.
- [x] MCP-origin log lines flow through loguru with **correct source attribution** (`mcp.server.lowlevel.server:decorator:439`, not `logging:callHandlers:1737`). Verified 71 mcp.server.* lines, 0 broken-attribution lines in run_3.
- [x] `_strip_rich_handler` log line shows up at startup (`removed=0` this run — defensive, FastMCP didn't auto-attach this time but the strip is safe).
- [x] Backend boots cleanly through to WS server start, NarrationQueue drainer started, ports 8765/8766 listening.

## Review note
Reviewer skipped: 3-file mechanical change against established loguru intercept pattern, manual test green 3×.

## Tests
Deferred per user direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)