### PR TITLE
feat(narration): MCP tools + HTTP + Activity panel + quiet mode (#93 Phase 2)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -401,6 +401,16 @@ voice:
   # Phrase cache
   cache_directory: "data/voice_cache"
 
+narration:
+  enabled: true
+  update_voice: false
+  urgent_max_wait_seconds: 30
+  completion_batch_seconds: 10
+  per_source_rate_limit:
+    items: 6
+    window_seconds: 60
+  quiet_mode_default_minutes: 60
+
 notifications:
   wife:
     enabled: true

--- a/frontend/src/app/panels.ts
+++ b/frontend/src/app/panels.ts
@@ -19,6 +19,7 @@ import { DevPanel } from '@features/dev';
 import { SelfFixPanel } from '@features/selffix';
 import { GitLabPanel } from '@features/gitlab';
 import { LogPanel } from '@features/log';
+import { ActivityPanel } from '@features/activity';
 // ── Shared panel props ────────────────────────────────────────────────────────
 
 export interface PanelSharedProps {
@@ -110,6 +111,13 @@ export const PANELS: ReadonlyArray<PanelSpec> = [
         icon: '≡',
         homeSlot: 'B3',
         Component: LogPanel as ComponentType<PanelSharedProps>,
+    },
+    {
+        id: 'activity',
+        title: 'Activity',
+        icon: '◉',
+        homeSlot: 'R2',
+        Component: ActivityPanel as ComponentType<PanelSharedProps>,
     },
 ];
 

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -14,6 +14,7 @@ import orbStateReducer from '@features/orbState/orbStateSlice';
 import conversationReducer from '@features/conversation/conversationSlice';
 import audioPlaybackReducer from '@core/audio/audioPlaybackSlice';
 import deviceReducer from '@features/device/deviceSlice';
+import activityReducer from '@features/activity/activitySlice';
 export const rootReducer = combineReducers({
     [baseApi.reducerPath]: baseApi.reducer,
     [weatherApi.reducerPath]: weatherApi.reducer,
@@ -30,6 +31,7 @@ export const rootReducer = combineReducers({
     conversation: conversationReducer,
     audioPlayback: audioPlaybackReducer,
     device: deviceReducer,
+    activity: activityReducer,
     // github has no slice — RTK Query cache only.
 });
 

--- a/frontend/src/common/types/panels.ts
+++ b/frontend/src/common/types/panels.ts
@@ -9,7 +9,8 @@ export type PanelId =
     | 'transcript'
     | 'selffix'
     | 'gitlab'
-    | 'log';
+    | 'log'
+    | 'activity';
 
 export type PanelMode = 'compact' | 'expanded';
 

--- a/frontend/src/features/activity/activityApi.ts
+++ b/frontend/src/features/activity/activityApi.ts
@@ -1,0 +1,31 @@
+import { baseApi } from '@core/api/baseApi';
+import { wsClient } from '@core/websocket/wsClient';
+import { narrationStateReceived, activityPanelReceived } from './activitySlice';
+import type { NarrationStatePayload, ActivityPanelPayload } from './types';
+
+export const activityApi = baseApi.injectEndpoints({
+    endpoints: (builder) => ({
+        streamActivity: builder.query<null, void>({
+            queryFn: () => ({ data: null }),
+            async onCacheEntryAdded(_arg, { cacheDataLoaded, cacheEntryRemoved, dispatch }) {
+                await cacheDataLoaded;
+
+                const unsubNarration = wsClient.subscribe<{ type: string; payload: NarrationStatePayload }>(
+                    'narration_state',
+                    (msg) => dispatch(narrationStateReceived(msg.payload)),
+                );
+
+                const unsubActivity = wsClient.subscribe<{ type: string; payload: ActivityPanelPayload }>(
+                    'activity_panel',
+                    (msg) => dispatch(activityPanelReceived(msg.payload)),
+                );
+
+                await cacheEntryRemoved;
+                unsubNarration();
+                unsubActivity();
+            },
+        }),
+    }),
+});
+
+export const { useStreamActivityQuery } = activityApi;

--- a/frontend/src/features/activity/activitySelectors.ts
+++ b/frontend/src/features/activity/activitySelectors.ts
@@ -1,0 +1,30 @@
+import { createSelector } from '@reduxjs/toolkit';
+import type { RootState } from '@app';
+import type { NarrationItem, NarrationEngineState, SourceEntry } from './types';
+
+const selectActivitySlice = (state: RootState) => state.activity;
+
+export const selectActivityState = createSelector(
+    selectActivitySlice,
+    (slice): NarrationEngineState => slice.state,
+);
+
+export const selectQuietUntil = createSelector(
+    selectActivitySlice,
+    (slice): string | null => slice.quietUntil,
+);
+
+export const selectActivitySources = createSelector(
+    selectActivitySlice,
+    (slice): Record<string, SourceEntry> => slice.sources,
+);
+
+export const selectActivityHistory = createSelector(
+    selectActivitySlice,
+    (slice): NarrationItem[] => slice.history,
+);
+
+export const selectActivityHasLiveData = createSelector(
+    selectActivitySlice,
+    (slice): boolean => slice.hasLiveData,
+);

--- a/frontend/src/features/activity/activitySlice.ts
+++ b/frontend/src/features/activity/activitySlice.ts
@@ -1,0 +1,55 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { NarrationItem, NarrationEngineState, SourceEntry, NarrationStatePayload, ActivityPanelPayload } from './types';
+
+const MAX_HISTORY = 20;
+
+export interface ActivityState {
+    /** Current engine state from `narration_state` messages. */
+    state: NarrationEngineState;
+    /** ISO 8601 quiet-until timestamp, or null when quiet mode is off. */
+    quietUntil: string | null;
+    /** Per-source status map from `activity_panel` messages. */
+    sources: Record<string, SourceEntry>;
+    /** Narration history — newest first, capped at MAX_HISTORY. */
+    history: NarrationItem[];
+    /** True once any live WS data has arrived. */
+    hasLiveData: boolean;
+}
+
+const initialState: ActivityState = {
+    state: 'idle',
+    quietUntil: null,
+    sources: {},
+    history: [],
+    hasLiveData: false,
+};
+
+const activitySlice = createSlice({
+    name: 'activity',
+    initialState,
+    reducers: {
+        narrationStateReceived(state, action: PayloadAction<NarrationStatePayload>) {
+            state.hasLiveData = true;
+            state.state = action.payload.state;
+            state.quietUntil = action.payload.quiet_until;
+            // Merge incoming items into history, dedup by id, newest first, cap at max.
+            const incomingIds = new Set(action.payload.items.map((i) => i.id));
+            const existing = state.history.filter((i) => !incomingIds.has(i.id));
+            const merged = [...action.payload.items, ...existing];
+            state.history = merged.length > MAX_HISTORY ? merged.slice(0, MAX_HISTORY) : merged;
+        },
+        activityPanelReceived(state, action: PayloadAction<ActivityPanelPayload>) {
+            state.hasLiveData = true;
+            state.sources = action.payload.sources;
+            // Merge history — dedup by id, newest first, cap at max.
+            const incomingIds = new Set(action.payload.history.map((i) => i.id));
+            const existing = state.history.filter((i) => !incomingIds.has(i.id));
+            const merged = [...action.payload.history, ...existing];
+            state.history = merged.length > MAX_HISTORY ? merged.slice(0, MAX_HISTORY) : merged;
+        },
+    },
+});
+
+export const { narrationStateReceived, activityPanelReceived } = activitySlice.actions;
+export default activitySlice.reducer;

--- a/frontend/src/features/activity/components/ActivityPanel/ActivityHistoryList.tsx
+++ b/frontend/src/features/activity/components/ActivityPanel/ActivityHistoryList.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react';
+import type { ActivityHistoryListProps } from './ActivityPanel.types';
+import { severityBadgeClasses, relativeTime } from './utils';
+
+export function ActivityHistoryList({ history }: ActivityHistoryListProps): ReactElement {
+    if (history.length === 0) {
+        return (
+            <div className="px-3 py-2 text-[10px] text-slate-500 italic">
+                No recent narrations.
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-0.5 px-2 py-1 overflow-y-auto min-h-0">
+            {history.map((item) => (
+                <div
+                    key={item.id}
+                    className="flex flex-col gap-0.5 px-1 py-1 hover:bg-slate-800/30 rounded-sm"
+                >
+                    <div className="flex items-center gap-2">
+                        <span
+                            className={`text-[8px] px-1.5 py-0.5 rounded-sm font-mono shrink-0 ${severityBadgeClasses(item.severity)}`}
+                        >
+                            {item.severity}
+                        </span>
+                        {item.source !== null && (
+                            <span className="text-[9px] text-slate-500 font-mono truncate min-w-0">
+                                {item.source}
+                            </span>
+                        )}
+                        <span className="text-[9px] text-slate-600 ml-auto shrink-0">
+                            {relativeTime(item.created_at)}
+                        </span>
+                    </div>
+                    <p className="text-[10px] text-slate-300 leading-tight line-clamp-2 px-0.5">
+                        {item.text}
+                    </p>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default ActivityHistoryList;

--- a/frontend/src/features/activity/components/ActivityPanel/ActivityPanel.tsx
+++ b/frontend/src/features/activity/components/ActivityPanel/ActivityPanel.tsx
@@ -1,0 +1,50 @@
+/**
+ * ActivityPanel — real-time narration activity feed.
+ * Shows quiet-mode indicator, per-source status, and narration history.
+ * Always visible in the HUD; data flows from the activity Redux slice
+ * populated by `narration_state` and `activity_panel` WS messages.
+ */
+import type { ReactElement } from 'react';
+import { useActivity } from '../../hooks/useActivity';
+import { ActivityQuietBar } from './ActivityQuietBar';
+import { ActivitySourceList } from './ActivitySourceList';
+import { ActivityHistoryList } from './ActivityHistoryList';
+import type { ActivityPanelProps } from './ActivityPanel.types';
+
+export function ActivityPanel({ mode = 'expanded' }: ActivityPanelProps): ReactElement {
+    const { quietUntil, sources, history, hasLiveData } = useActivity();
+
+    if (!hasLiveData) {
+        return (
+            <div className="flex flex-col h-full">
+                <div className="px-3 py-2 text-[10px] text-slate-500 italic">
+                    Waiting for activity data…
+                </div>
+            </div>
+        );
+    }
+
+    if (mode === 'compact') {
+        return (
+            <div className="flex flex-col">
+                {quietUntil !== null && <ActivityQuietBar quietUntil={quietUntil} />}
+                <ActivityHistoryList history={history.slice(0, 5)} />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            {quietUntil !== null && <ActivityQuietBar quietUntil={quietUntil} />}
+            <ActivitySourceList sources={sources} />
+            <div className="flex-1 min-h-0 overflow-y-auto">
+                <div className="text-[9px] text-slate-500 uppercase tracking-widest px-3 pt-2 pb-1">
+                    History
+                </div>
+                <ActivityHistoryList history={history} />
+            </div>
+        </div>
+    );
+}
+
+export default ActivityPanel;

--- a/frontend/src/features/activity/components/ActivityPanel/ActivityPanel.types.ts
+++ b/frontend/src/features/activity/components/ActivityPanel/ActivityPanel.types.ts
@@ -1,0 +1,18 @@
+import type { PanelMode } from '@common/types';
+import type { NarrationItem, SourceEntry } from '../../types';
+
+export interface ActivityPanelProps {
+    mode?: PanelMode;
+}
+
+export interface ActivitySourceListProps {
+    sources: Record<string, SourceEntry>;
+}
+
+export interface ActivityHistoryListProps {
+    history: NarrationItem[];
+}
+
+export interface ActivityQuietBarProps {
+    quietUntil: string;
+}

--- a/frontend/src/features/activity/components/ActivityPanel/ActivityQuietBar.tsx
+++ b/frontend/src/features/activity/components/ActivityPanel/ActivityQuietBar.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from 'react';
+import type { ActivityQuietBarProps } from './ActivityPanel.types';
+import { formatQuietUntilTime } from './utils';
+
+export function ActivityQuietBar({ quietUntil }: ActivityQuietBarProps): ReactElement {
+    const until = formatQuietUntilTime(quietUntil);
+    return (
+        <div className="flex items-center gap-2 px-3 py-1.5 bg-amber-900/50 border-b border-amber-700/50">
+            <span className="text-amber-400 text-[9px] font-bold tracking-widest">QUIET MODE</span>
+            <span className="text-amber-300/70 text-[9px]">— until {until}</span>
+        </div>
+    );
+}
+
+export default ActivityQuietBar;

--- a/frontend/src/features/activity/components/ActivityPanel/ActivitySourceList.tsx
+++ b/frontend/src/features/activity/components/ActivityPanel/ActivitySourceList.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from 'react';
+import type { ActivitySourceListProps } from './ActivityPanel.types';
+import { statusBadgeClasses } from './utils';
+
+export function ActivitySourceList({ sources }: ActivitySourceListProps): ReactElement {
+    const entries = Object.entries(sources);
+
+    if (entries.length === 0) {
+        return (
+            <div className="px-3 py-2 text-[10px] text-slate-500 italic">No active sources.</div>
+        );
+    }
+
+    return (
+        <div className="px-2 py-1 border-b border-slate-700/40">
+            <div className="text-[9px] text-slate-500 uppercase tracking-widest px-1 mb-1">
+                Sources
+            </div>
+            {entries.map(([source, entry]) => (
+                <div key={source} className="flex items-center gap-2 py-0.5 px-1">
+                    <span
+                        className={`text-[8px] px-1.5 py-0.5 rounded-sm font-mono shrink-0 ${statusBadgeClasses(entry.status)}`}
+                    >
+                        {entry.status}
+                    </span>
+                    <span className="text-[10px] text-slate-300 font-mono truncate min-w-0">
+                        {source}
+                    </span>
+                    {entry.message.length > 0 && (
+                        <span className="text-[9px] text-slate-500 truncate min-w-0">
+                            — {entry.message}
+                        </span>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default ActivitySourceList;

--- a/frontend/src/features/activity/components/ActivityPanel/constants.ts
+++ b/frontend/src/features/activity/components/ActivityPanel/constants.ts
@@ -1,0 +1,2 @@
+/** Maximum number of history items displayed in the panel. */
+export const MAX_VISIBLE_HISTORY = 20;

--- a/frontend/src/features/activity/components/ActivityPanel/index.ts
+++ b/frontend/src/features/activity/components/ActivityPanel/index.ts
@@ -1,0 +1,2 @@
+export { ActivityPanel, default } from './ActivityPanel';
+export type { ActivityPanelProps } from './ActivityPanel.types';

--- a/frontend/src/features/activity/components/ActivityPanel/utils.ts
+++ b/frontend/src/features/activity/components/ActivityPanel/utils.ts
@@ -1,0 +1,59 @@
+import type { NarrationSeverity, SourceStatus } from '../../types';
+
+/**
+ * Returns Tailwind class names for a severity badge.
+ * Used by ActivityHistoryList for colour-coded item badges.
+ */
+export function severityBadgeClasses(severity: NarrationSeverity): string {
+    switch (severity) {
+        case 'info':
+            return 'bg-blue-900/40 text-blue-300 border border-blue-700/50';
+        case 'update':
+            return 'bg-cyan-900/40 text-cyan-300 border border-cyan-700/50';
+        case 'urgent':
+            return 'bg-red-900/40 text-red-400 border border-red-700/50';
+        case 'completion':
+            return 'bg-green-900/40 text-green-300 border border-green-700/50';
+    }
+}
+
+/**
+ * Returns Tailwind class names for a source-status badge.
+ */
+export function statusBadgeClasses(status: SourceStatus): string {
+    switch (status) {
+        case 'starting':
+            return 'bg-slate-800/50 text-slate-300 border border-slate-600/50';
+        case 'in_progress':
+            return 'bg-cyan-900/40 text-cyan-300 border border-cyan-700/50';
+        case 'done':
+            return 'bg-green-900/40 text-green-300 border border-green-700/50';
+        case 'blocked':
+            return 'bg-red-900/40 text-red-400 border border-red-700/50';
+    }
+}
+
+/**
+ * Formats an ISO 8601 timestamp as a relative time string (e.g. "2m ago", "just now").
+ * Designed for display in the activity history list.
+ */
+export function relativeTime(iso: string): string {
+    const diffMs = Date.now() - new Date(iso).getTime();
+    const diffSec = Math.floor(diffMs / 1000);
+    if (diffSec < 10) return 'just now';
+    if (diffSec < 60) return `${diffSec}s ago`;
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    return `${diffHr}h ago`;
+}
+
+/**
+ * Formats an ISO 8601 quiet-until timestamp as "HH:MM" (local time).
+ */
+export function formatQuietUntilTime(iso: string): string {
+    const d = new Date(iso);
+    const h = d.getHours().toString().padStart(2, '0');
+    const m = d.getMinutes().toString().padStart(2, '0');
+    return `${h}:${m}`;
+}

--- a/frontend/src/features/activity/hooks/useActivity.ts
+++ b/frontend/src/features/activity/hooks/useActivity.ts
@@ -1,0 +1,22 @@
+import { useAppSelector } from '@app';
+import { useStreamActivityQuery } from '../activityApi';
+import {
+    selectActivityState,
+    selectQuietUntil,
+    selectActivitySources,
+    selectActivityHistory,
+    selectActivityHasLiveData,
+} from '../activitySelectors';
+import type { UseActivityReturn } from './useActivity.types';
+
+export function useActivity(): UseActivityReturn {
+    useStreamActivityQuery();
+
+    const engineState = useAppSelector(selectActivityState);
+    const quietUntil = useAppSelector(selectQuietUntil);
+    const sources = useAppSelector(selectActivitySources);
+    const history = useAppSelector(selectActivityHistory);
+    const hasLiveData = useAppSelector(selectActivityHasLiveData);
+
+    return { engineState, quietUntil, sources, history, hasLiveData };
+}

--- a/frontend/src/features/activity/hooks/useActivity.types.ts
+++ b/frontend/src/features/activity/hooks/useActivity.types.ts
@@ -1,0 +1,9 @@
+import type { NarrationItem, NarrationEngineState, SourceEntry } from '../types';
+
+export interface UseActivityReturn {
+    engineState: NarrationEngineState;
+    quietUntil: string | null;
+    sources: Record<string, SourceEntry>;
+    history: NarrationItem[];
+    hasLiveData: boolean;
+}

--- a/frontend/src/features/activity/index.ts
+++ b/frontend/src/features/activity/index.ts
@@ -1,0 +1,24 @@
+// Public barrel — consumers import from '@features/activity', not from internal paths.
+export { ActivityPanel } from './components/ActivityPanel';
+export type { ActivityPanelProps } from './components/ActivityPanel';
+export { useActivity } from './hooks/useActivity';
+export type { UseActivityReturn } from './hooks/useActivity.types';
+export { activityApi, useStreamActivityQuery } from './activityApi';
+export { narrationStateReceived, activityPanelReceived } from './activitySlice';
+export type { ActivityState } from './activitySlice';
+export {
+    selectActivityState,
+    selectQuietUntil,
+    selectActivitySources,
+    selectActivityHistory,
+    selectActivityHasLiveData,
+} from './activitySelectors';
+export type {
+    NarrationItem,
+    NarrationSeverity,
+    NarrationEngineState,
+    SourceEntry,
+    SourceStatus,
+    NarrationStatePayload,
+    ActivityPanelPayload,
+} from './types';

--- a/frontend/src/features/activity/mock.ts
+++ b/frontend/src/features/activity/mock.ts
@@ -1,0 +1,61 @@
+/**
+ * Sample data for development / Storybook.
+ */
+import type { NarrationItem, SourceEntry } from './types';
+import type { ActivityState } from './activitySlice';
+
+export const MOCK_NARRATION_ITEMS: NarrationItem[] = [
+    {
+        id: '1',
+        text: 'Backend implementation complete — migrating to frontend next.',
+        severity: 'completion',
+        source: 'claude-code-91',
+        created_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+        ttl_seconds: null,
+    },
+    {
+        id: '2',
+        text: 'Running tests — 3 failures in auth module.',
+        severity: 'urgent',
+        source: 'claude-code-91',
+        created_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+        ttl_seconds: null,
+    },
+    {
+        id: '3',
+        text: 'Morning briefing scheduled for 08:00.',
+        severity: 'info',
+        source: 'morning-briefing',
+        created_at: new Date(Date.now() - 10 * 60_000).toISOString(),
+        ttl_seconds: 3600,
+    },
+    {
+        id: '4',
+        text: 'Spotify token refreshed successfully.',
+        severity: 'update',
+        source: 'spotify',
+        created_at: new Date(Date.now() - 15 * 60_000).toISOString(),
+        ttl_seconds: null,
+    },
+];
+
+export const MOCK_SOURCES: Record<string, SourceEntry> = {
+    'claude-code-91': {
+        status: 'in_progress',
+        message: 'Backend done, frontend next',
+        updated_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+    },
+    'morning-briefing': {
+        status: 'done',
+        message: 'Briefing delivered',
+        updated_at: new Date(Date.now() - 10 * 60_000).toISOString(),
+    },
+};
+
+export const MOCK_ACTIVITY_STATE: ActivityState = {
+    state: 'active_dialogue',
+    quietUntil: null,
+    sources: MOCK_SOURCES,
+    history: MOCK_NARRATION_ITEMS,
+    hasLiveData: true,
+};

--- a/frontend/src/features/activity/types.ts
+++ b/frontend/src/features/activity/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Activity feature types — NarrationItem, NarrationState, and WS payload shapes.
+ */
+
+/** Severity of a narration item — maps to colour-coded badges in the UI. */
+export type NarrationSeverity = 'info' | 'update' | 'urgent' | 'completion';
+
+/** Operational state emitted by the backend narration engine. */
+export type NarrationEngineState = 'idle' | 'listening' | 'speaking' | 'active_dialogue';
+
+/** Per-source activity status emitted by the backend. */
+export type SourceStatus = 'starting' | 'in_progress' | 'done' | 'blocked';
+
+/** A single item in the narration queue / history — mirrors the backend dataclass. */
+export interface NarrationItem {
+    id: string;
+    text: string;
+    severity: NarrationSeverity;
+    source: string | null;
+    /** ISO 8601 timestamp. */
+    created_at: string;
+    /** Optional TTL in seconds. */
+    ttl_seconds: number | null;
+}
+
+/** Per-source status row emitted in the activity_panel payload. */
+export interface SourceEntry {
+    status: SourceStatus;
+    message: string;
+    /** ISO 8601 timestamp of the last status update. */
+    updated_at: string;
+}
+
+/** WS payload for `narration_state` message type. */
+export interface NarrationStatePayload {
+    state: NarrationEngineState;
+    /** ISO 8601 or null when quiet mode is off. */
+    quiet_until: string | null;
+    items: NarrationItem[];
+}
+
+/** WS payload for `activity_panel` message type. */
+export interface ActivityPanelPayload {
+    sources: Record<string, SourceEntry>;
+    history: NarrationItem[];
+}

--- a/src/api/mcp_tools/__init__.py
+++ b/src/api/mcp_tools/__init__.py
@@ -11,6 +11,7 @@ Tool naming convention: flat snake_case with a namespace prefix, e.g.
 from api.mcp_tools import (  # noqa: F401
     github_tools,
     gitlab_tools,
+    narration_tools,
     pc_control_tools,
     smart_home_tools,
     spotify_tools,
@@ -20,6 +21,7 @@ from api.mcp_tools import (  # noqa: F401
 __all__ = [
     "github_tools",
     "gitlab_tools",
+    "narration_tools",
     "pc_control_tools",
     "smart_home_tools",
     "spotify_tools",

--- a/src/api/mcp_tools/narration_tools.py
+++ b/src/api/mcp_tools/narration_tools.py
@@ -1,0 +1,258 @@
+"""MCP tool registrations for the narration/notification namespace.
+
+Registers three MCP tools that let background agents (Claude Code, etc.) push
+notifications and status updates to the JARVIS narration queue:
+
+  - ``jarvis_notify``          — enqueue a NarrationItem.
+  - ``jarvis_set_status``      — coalesce per-source progress.
+  - ``jarvis_set_quiet_mode``  — toggle quiet mode.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from api.mcp_server import register_tool
+from utils.logger import get_logger
+
+logger = get_logger("mcp_tools.narration")
+
+
+def _get_narration_queue() -> Any:
+    """Return the process-wide NarrationQueue from ws_server, or None."""
+    try:
+        from api.ws_server import get_narration_queue  # noqa: PLC0415
+
+        return get_narration_queue()
+    except ImportError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# jarvis_notify
+# ---------------------------------------------------------------------------
+
+_NOTIFY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "description": "Short title for the notification / narration item.",
+        },
+        "body": {
+            "type": "string",
+            "description": "Optional longer body text. When provided it is "
+            "appended to the title with a colon separator.",
+        },
+        "severity": {
+            "type": "string",
+            "enum": ["info", "update", "urgent", "completion"],
+            "description": (
+                "Routing severity: info=HUD only; update=HUD+(optional voice); "
+                "urgent=voice+HUD, bypasses quiet mode; completion=voice+HUD, batched."
+            ),
+        },
+        "source": {
+            "type": "string",
+            "description": "Caller identifier used for rate limiting and batching "
+            "(e.g. 'claude-code-91'). Optional.",
+        },
+        "ttl_seconds": {
+            "type": "integer",
+            "description": "Seconds until the item expires (0 = never).",
+            "minimum": 0,
+        },
+    },
+    "required": ["title"],
+}
+
+
+@register_tool(
+    name="jarvis_notify",
+    description=(
+        "File a notification into the JARVIS narration queue. "
+        "The item is narrated aloud (when voice-eligible and JARVIS is idle) "
+        "and shown on the HUD activity panel immediately."
+    ),
+    schema=_NOTIFY_SCHEMA,
+)
+async def jarvis_notify(
+    title: str,
+    body: str | None = None,
+    severity: str = "update",
+    source: str | None = None,
+    ttl_seconds: int = 0,
+) -> dict[str, Any]:
+    """Enqueue a NarrationItem from an external MCP caller.
+
+    Args:
+        title: Short notification title.
+        body: Optional additional detail appended to title.
+        severity: ``info``, ``update``, ``urgent``, or ``completion``.
+        source: Optional caller identifier for rate limiting and batching.
+        ttl_seconds: Item lifetime in seconds (0 = no expiry).
+
+    Returns:
+        Dict with ``item_id``, ``queued_at`` (ISO 8601), and ``channels``.
+    """
+    valid_severities = {"info", "update", "urgent", "completion"}
+    if severity not in valid_severities:
+        severity = "update"
+
+    text = f"{title}: {body}" if body else title
+
+    queue = _get_narration_queue()
+    if queue is None:
+        logger.warning("jarvis_notify: NarrationQueue not available — item dropped")
+        return {
+            "item_id": f"narr-{uuid.uuid4().hex[:8]}",
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "channels": [],
+            "error": "NarrationQueue not initialised",
+        }
+
+    item_id = queue.enqueue(
+        text=text,
+        severity=severity,  # type: ignore[arg-type]
+        source=source,
+        ttl_seconds=float(ttl_seconds),
+    )
+    channels = queue._resolve_channels(severity)  # type: ignore[arg-type]
+
+    logger.info(
+        f"MCP jarvis_notify: [{severity}] {item_id!r}"
+        + (f" source={source!r}" if source else "")
+    )
+    return {
+        "item_id": item_id,
+        "queued_at": datetime.now(timezone.utc).isoformat(),
+        "channels": channels,
+    }
+
+
+# ---------------------------------------------------------------------------
+# jarvis_set_status
+# ---------------------------------------------------------------------------
+
+_SET_STATUS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "source": {
+            "type": "string",
+            "description": "Caller / task identifier (e.g. 'claude-code-91').",
+        },
+        "status": {
+            "type": "string",
+            "enum": ["starting", "in_progress", "done", "blocked"],
+            "description": "Current status of the background task.",
+        },
+        "message": {
+            "type": "string",
+            "description": "Optional human-readable status detail.",
+        },
+    },
+    "required": ["source", "status"],
+}
+
+
+@register_tool(
+    name="jarvis_set_status",
+    description=(
+        "Update the per-source progress status shown in the JARVIS HUD activity panel. "
+        "Replaces any prior status from the same source. Does not enqueue a voice item."
+    ),
+    schema=_SET_STATUS_SCHEMA,
+)
+async def jarvis_set_status(
+    source: str,
+    status: str,
+    message: str | None = None,
+) -> dict[str, Any]:
+    """Coalesce per-source progress status into the narration queue.
+
+    Args:
+        source: Unique caller identifier.
+        status: One of ``starting``, ``in_progress``, ``done``, ``blocked``.
+        message: Optional human-readable detail.
+
+    Returns:
+        Dict with ``source`` and ``prior_status`` (None if first update).
+    """
+    valid_statuses = {"starting", "in_progress", "done", "blocked"}
+    if status not in valid_statuses:
+        status = "in_progress"
+
+    queue = _get_narration_queue()
+    if queue is None:
+        logger.warning("jarvis_set_status: NarrationQueue not available")
+        return {"source": source, "prior_status": None, "error": "NarrationQueue not initialised"}
+
+    prior = queue.set_source_status(
+        source=source,
+        status=status,  # type: ignore[arg-type]
+        message=message,
+    )
+    prior_status: str | None = prior.status if prior is not None else None
+
+    logger.info(f"MCP jarvis_set_status: source={source!r} → {status!r}")
+    return {"source": source, "prior_status": prior_status}
+
+
+# ---------------------------------------------------------------------------
+# jarvis_set_quiet_mode
+# ---------------------------------------------------------------------------
+
+_SET_QUIET_MODE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "enabled": {
+            "type": "boolean",
+            "description": "True to enable quiet mode, False to disable it.",
+        },
+        "duration_minutes": {
+            "type": "integer",
+            "description": "How long to stay quiet (minutes). "
+            "Omit to use the configured default (60 min).",
+            "minimum": 1,
+        },
+    },
+    "required": ["enabled"],
+}
+
+
+@register_tool(
+    name="jarvis_set_quiet_mode",
+    description=(
+        "Enable or disable JARVIS quiet mode. While active, all narration items route "
+        "to HUD only — except 'urgent' which still plays voice with a soft pre-roll. "
+        "Enabling while already quiet replaces the timer (no stacking)."
+    ),
+    schema=_SET_QUIET_MODE_SCHEMA,
+)
+async def jarvis_set_quiet_mode(
+    enabled: bool,
+    duration_minutes: int | None = None,
+) -> dict[str, Any]:
+    """Toggle JARVIS quiet mode.
+
+    Args:
+        enabled: True to enter quiet mode, False to leave it.
+        duration_minutes: Duration in minutes (None = use configured default).
+
+    Returns:
+        Dict with ``quiet_until`` (ISO 8601 string or None).
+    """
+    queue = _get_narration_queue()
+    if queue is None:
+        logger.warning("jarvis_set_quiet_mode: NarrationQueue not available")
+        return {"quiet_until": None, "error": "NarrationQueue not initialised"}
+
+    quiet_until = queue.set_quiet_mode(enabled=enabled, duration_minutes=duration_minutes)
+    quiet_until_iso: str | None = quiet_until.isoformat() if quiet_until is not None else None
+
+    logger.info(
+        f"MCP jarvis_set_quiet_mode: enabled={enabled} quiet_until={quiet_until_iso}"
+    )
+    return {"quiet_until": quiet_until_iso}

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -1559,8 +1559,13 @@ async def broadcast_activity_panel() -> None:
     """
     if _narration_queue is None:
         return
-    statuses = _narration_queue.get_source_statuses()
-    message = json.dumps({"type": "activity_panel", "payload": {"sources": statuses}})
+    message = json.dumps({
+        "type": "activity_panel",
+        "payload": {
+            "sources": _narration_queue.get_source_statuses(),
+            "history": _narration_queue.get_history(),
+        },
+    })
     await _broadcast(message)
 
 

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -150,6 +150,11 @@ _jarvis_spotify_device_id: str | None = None
 _MISSING: object = object()
 
 
+def get_narration_queue() -> "NarrationQueue | None":
+    """Return the process-wide NarrationQueue singleton, or None if not initialised."""
+    return _narration_queue
+
+
 def get_spotify_client() -> SpotifyClient | None:
     """Return the process-wide SpotifyClient singleton, or None if not initialised."""
     return _spotify_client
@@ -1530,6 +1535,164 @@ async def broadcast_turn_timing(timing: dict[str, Any]) -> None:
     """
     message = json.dumps({"type": "turn_timing", "payload": timing})
     await _broadcast(message)
+
+
+async def broadcast_narration_state() -> None:
+    """Broadcast the current narration queue state to all connected clients.
+
+    Emitted on every queue mutation: enqueue, dequeue, quiet-mode toggle,
+    status update.  The frontend ``activity`` feature subscribes to
+    ``narration_state`` messages to keep the Activity panel in sync.
+    """
+    if _narration_queue is None:
+        return
+    payload = _narration_queue.get_state_snapshot()
+    message = json.dumps({"type": "narration_state", "payload": payload})
+    await _broadcast(message)
+
+
+async def broadcast_activity_panel() -> None:
+    """Broadcast the per-source status snapshot to all connected clients.
+
+    Emitted alongside :func:`broadcast_narration_state` so the Activity panel
+    can display per-source progress without polling.
+    """
+    if _narration_queue is None:
+        return
+    statuses = _narration_queue.get_source_statuses()
+    message = json.dumps({"type": "activity_panel", "payload": {"sources": statuses}})
+    await _broadcast(message)
+
+
+async def _on_narration_queue_mutation() -> None:
+    """Internal callback wired into NarrationQueue — fires both WS broadcasts."""
+    await broadcast_narration_state()
+    await broadcast_activity_panel()
+
+
+# ---------------------------------------------------------------------------
+# HTTP handlers: POST /api/jarvis/notify|status|quiet
+# ---------------------------------------------------------------------------
+
+
+async def jarvis_notify_handler(request: web.Request) -> web.Response:
+    """Handle POST /api/jarvis/notify — enqueue a narration item from an HTTP caller.
+
+    Accepts the same payload as the ``jarvis_notify`` MCP tool:
+    ``{"title": str, "body": str|null, "severity": str, "source": str|null,
+    "ttl_seconds": int}``.
+
+    Returns JSON ``{"item_id": str, "queued_at": str, "channels": [...]}``.
+    """
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    if _narration_queue is None:
+        return web.json_response({"error": "NarrationQueue not initialised"}, status=503)
+
+    try:
+        data: dict[str, Any] = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+
+    title: str = data.get("title", "")
+    if not title:
+        return web.json_response({"error": "'title' is required"}, status=400)
+
+    body: str | None = data.get("body")
+    severity: str = data.get("severity", "update")
+    if severity not in {"info", "update", "urgent", "completion"}:
+        severity = "update"
+    source: str | None = data.get("source")
+    ttl_seconds: float = float(data.get("ttl_seconds", 0))
+
+    text = f"{title}: {body}" if body else title
+    item_id = _narration_queue.enqueue(
+        text=text,
+        severity=severity,  # type: ignore[arg-type]
+        source=source,
+        ttl_seconds=ttl_seconds,
+    )
+    channels = _narration_queue._resolve_channels(severity)  # type: ignore[arg-type]
+
+    logger.info(
+        f"HTTP /api/jarvis/notify: [{severity}] {item_id!r}"
+        + (f" source={source!r}" if source else "")
+    )
+    return web.json_response(
+        {
+            "item_id": item_id,
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "channels": channels,
+        }
+    )
+
+
+async def jarvis_status_handler(request: web.Request) -> web.Response:
+    """Handle POST /api/jarvis/status — coalesce per-source progress status.
+
+    Accepts ``{"source": str, "status": str, "message": str|null}``.
+    Returns JSON ``{"source": str, "prior_status": str|null}``.
+    """
+    if _narration_queue is None:
+        return web.json_response({"error": "NarrationQueue not initialised"}, status=503)
+
+    try:
+        data = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+
+    source: str = data.get("source", "")
+    if not source:
+        return web.json_response({"error": "'source' is required"}, status=400)
+
+    status: str = data.get("status", "in_progress")
+    if status not in {"starting", "in_progress", "done", "blocked"}:
+        status = "in_progress"
+    message: str | None = data.get("message")
+
+    prior = _narration_queue.set_source_status(
+        source=source,
+        status=status,  # type: ignore[arg-type]
+        message=message,
+    )
+    prior_status: str | None = prior.status if prior is not None else None
+
+    logger.info(f"HTTP /api/jarvis/status: source={source!r} → {status!r}")
+    return web.json_response({"source": source, "prior_status": prior_status})
+
+
+async def jarvis_quiet_handler(request: web.Request) -> web.Response:
+    """Handle POST /api/jarvis/quiet — toggle quiet mode.
+
+    Accepts ``{"enabled": bool, "duration_minutes": int|null}``.
+    Returns JSON ``{"quiet_until": str|null}``.
+    """
+    if _narration_queue is None:
+        return web.json_response({"error": "NarrationQueue not initialised"}, status=503)
+
+    try:
+        data = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+
+    enabled: bool = bool(data.get("enabled", False))
+    duration_minutes_raw = data.get("duration_minutes")
+    duration_minutes: int | None = (
+        int(duration_minutes_raw) if duration_minutes_raw is not None else None
+    )
+
+    quiet_until = _narration_queue.set_quiet_mode(
+        enabled=enabled,
+        duration_minutes=duration_minutes,
+    )
+    quiet_until_iso: str | None = (
+        quiet_until.isoformat() if quiet_until is not None else None
+    )
+
+    logger.info(
+        f"HTTP /api/jarvis/quiet: enabled={enabled} quiet_until={quiet_until_iso}"
+    )
+    return web.json_response({"quiet_until": quiet_until_iso})
 
 
 async def _broadcast(message: str) -> None:
@@ -4417,11 +4580,20 @@ async def start_ws_server(
     logger.info("Initialising LLM client (OpenClaw-backed)...")
     claude_client = await create_claude_client(openclaw_client=_openclaw_client)
 
-    # Conversation state machine + narration queue (#93 Phase 1).
+    # Conversation state machine + narration queue (#93 Phase 1 + 2).
+    narration_cfg = cfg.get_section("narration") or {}
+    rate_cfg: dict[str, Any] = narration_cfg.get("per_source_rate_limit") or {}
     _state_machine = ConversationStateMachine()
     _narration_queue = NarrationQueue(
         state_machine=_state_machine,
         tts_emit=_emit_synthetic_utterance,
+        update_voice=bool(narration_cfg.get("update_voice", False)),
+        urgent_max_wait_seconds=float(narration_cfg.get("urgent_max_wait_seconds", 30)),
+        completion_batch_seconds=float(narration_cfg.get("completion_batch_seconds", 10)),
+        rate_limit_items=int(rate_cfg.get("items", 6)),
+        rate_limit_window_seconds=float(rate_cfg.get("window_seconds", 60)),
+        quiet_mode_default_minutes=int(narration_cfg.get("quiet_mode_default_minutes", 60)),
+        on_queue_mutation=_on_narration_queue_mutation,
     )
     _narration_queue.start()
     _narration_drainer_task = None  # task handle is owned by NarrationQueue.start()
@@ -4496,6 +4668,10 @@ async def start_ws_server(
     http_app.router.add_post("/api/spotify/play/context", spotify_play_context_handler)
     http_app.router.add_post("/api/spotify/play/uris", spotify_play_uris_handler)
     http_app.router.add_get("/api/spotify/token", spotify_token_handler)
+    # Narration / activity endpoints (#93 Phase 2)
+    http_app.router.add_post("/api/jarvis/notify", jarvis_notify_handler)
+    http_app.router.add_post("/api/jarvis/status", jarvis_status_handler)
+    http_app.router.add_post("/api/jarvis/quiet", jarvis_quiet_handler)
 
     # Start WebSocket server
     ws_runner = web.AppRunner(ws_app)

--- a/src/brain/agents/quiet_mode_agent.py
+++ b/src/brain/agents/quiet_mode_agent.py
@@ -1,0 +1,113 @@
+"""QuietModeAgent — handles QUIET_MODE_ON / QUIET_MODE_OFF intents (#93 Phase 2).
+
+Receives the two quiet-mode intents from the orchestrator, calls the shared
+NarrationQueue's ``set_quiet_mode`` method, and returns a spoken acknowledgment
+in JARVIS persona (German or English depending on the turn language).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from brain.agents.base import AgentResult, BaseAgent
+from utils.config_loader import get_config
+from utils.logger import get_logger
+
+logger = get_logger("agent.quiet_mode")
+
+
+class QuietModeAgent(BaseAgent):
+    """Handles quiet-mode voice intents and delegates to the NarrationQueue."""
+
+    def __init__(self, narration_queue: Any) -> None:
+        """Initialise the agent.
+
+        Args:
+            narration_queue: The shared :class:`brain.narration_queue.NarrationQueue`
+                instance, or None when not yet initialised. The agent will still
+                return a graceful error response when the queue is None.
+        """
+        super().__init__()
+        self._narration_queue = narration_queue
+
+    async def run(
+        self,
+        task: str,
+        params: dict[str, Any],
+        language: str,
+    ) -> AgentResult:
+        """Execute the quiet-mode intent.
+
+        Dispatches on ``params["action"]``: ``"on"`` or ``"off"``.
+
+        Args:
+            task: Original STT utterance (unused — action is in params).
+            params: Dict with key ``action`` (``"on"`` or ``"off"``) and
+                optional ``duration_minutes`` for quiet-on.
+            language: Turn language (``"en"`` or ``"de"``).
+
+        Returns:
+            :class:`AgentResult` with a JARVIS-style spoken acknowledgment.
+        """
+        action: str = params.get("action", "on")
+        duration: int | None = params.get("duration_minutes")
+
+        if self._narration_queue is None:
+            logger.warning("QuietModeAgent: NarrationQueue not available")
+            response = (
+                "Entschuldigung, Sir — der Stille-Modus ist noch nicht verfügbar."
+                if language == "de"
+                else "Apologies, Sir — quiet mode is not available yet."
+            )
+            return AgentResult(spoken_response=response, success=False)
+
+        if action == "off":
+            self._narration_queue.set_quiet_mode(enabled=False)
+            response = self._ack_off(language)
+            logger.info("QuietModeAgent: quiet mode disabled")
+        else:
+            # Determine duration: use param, then config default, then 60.
+            if duration is None:
+                try:
+                    cfg = get_config()
+                    narration_cfg = cfg.get_section("narration") or {}
+                    duration = int(narration_cfg.get("quiet_mode_default_minutes", 60))
+                except Exception:
+                    duration = 60
+
+            self._narration_queue.set_quiet_mode(enabled=True, duration_minutes=duration)
+            response = self._ack_on(duration, language)
+            logger.info(f"QuietModeAgent: quiet mode enabled for {duration}min")
+
+        return AgentResult(spoken_response=response, success=True)
+
+    @staticmethod
+    def _ack_on(duration: int, language: str) -> str:
+        """Return the spoken acknowledgment for quiet-mode activation.
+
+        Args:
+            duration: Duration in minutes.
+            language: Turn language.
+
+        Returns:
+            JARVIS acknowledgment string.
+        """
+        if language == "de":
+            return (
+                f"Verstanden, Sir — ich halte mich für {duration} Minuten zurück."
+            )
+        return f"Understood, Sir — I'll keep quiet for {duration} minutes."
+
+    @staticmethod
+    def _ack_off(language: str) -> str:
+        """Return the spoken acknowledgment for quiet-mode deactivation.
+
+        Args:
+            language: Turn language.
+
+        Returns:
+            JARVIS acknowledgment string.
+        """
+        if language == "de":
+            return "Wieder zur Verfügung, Sir."
+        return "Back at your service, Sir."

--- a/src/brain/intent_parser.py
+++ b/src/brain/intent_parser.py
@@ -39,6 +39,8 @@ class Intent(Enum):
     SPOTIFY_PLAY_CONTEXT = "spotify_play_context"
     GREETING = "greeting"
     MORNING_BRIEFING = "morning_briefing"
+    QUIET_MODE_ON = "quiet_mode_on"
+    QUIET_MODE_OFF = "quiet_mode_off"
 
 
 @dataclass
@@ -512,6 +514,42 @@ INTENT_KEYWORDS: dict[Intent, dict[str, list[str]]] = {
             r"\bmein\s+briefing\b",
         ],
     },
+    # ------------------------------------------------------------------
+    # Quiet-mode intents (#93 Phase 2) — language-tolerant word-boundary
+    # patterns. The canonical fast-path below catches STT variants.
+    # ------------------------------------------------------------------
+    Intent.QUIET_MODE_ON: {
+        "en": [
+            r"\bbe\s+quiet\b",
+            r"\bgo\s+quiet\b",
+            r"\bquiet\s+mode\b",
+            r"\bstop\s+talking\b",
+            r"\bsilent\s+mode\b",
+        ],
+        "de": [
+            r"\bleise\s+arbeiten\b",
+            r"\bsei\s+leise\b",
+            r"\bruhig\s+sein\b",
+            r"\bstille\s+modus\b",
+            r"\bquiet\s+mode\b",
+        ],
+    },
+    Intent.QUIET_MODE_OFF: {
+        "en": [
+            r"\bspeak\s+again\b",
+            r"\bstop\s+quiet\b",
+            r"\bleave\s+quiet\s+mode\b",
+            r"\bback\s+(to\s+)?normal\b",
+            r"\byou\s+can\s+talk\s+again\b",
+        ],
+        "de": [
+            r"\bwieder\s+reden\b",
+            r"\brede\s+wieder\b",
+            r"\bquiet\s+mode\s+(aus|off)\b",
+            r"\bstille\s+modus\s+(aus|off)\b",
+            r"\bnormal\s+(modus|mode)\b",
+        ],
+    },
 }
 
 # ---------------------------------------------------------------------------
@@ -572,6 +610,59 @@ _CANONICAL_BRIEFING_PHRASES: tuple[str, ...] = (
     "tag's briefing",
     "tarches briefing",
 )
+
+
+# ---------------------------------------------------------------------------
+# Language-tolerant canonical quiet-mode phrases (#93 Phase 2).
+# Checked BEFORE language-specific pattern matching to catch STT mis-detection.
+# ---------------------------------------------------------------------------
+_CANONICAL_QUIET_ON_PHRASES: tuple[str, ...] = (
+    # German canonical
+    "leise arbeiten",
+    "sei leise",
+    "ruhig sein",
+    "stille modus",
+    "leiser modus",
+    # English canonical
+    "be quiet",
+    "go quiet",
+    "quiet mode",
+    "silent mode",
+    "stop talking",
+)
+
+_CANONICAL_QUIET_OFF_PHRASES: tuple[str, ...] = (
+    # German canonical
+    "wieder reden",
+    "rede wieder",
+    "quiet mode aus",
+    "quiet mode off",
+    "stille modus aus",
+    # English canonical
+    "speak again",
+    "stop quiet",
+    "leave quiet mode",
+    "back to normal",
+    "you can talk again",
+)
+
+
+def _is_canonical_quiet_on(text: str) -> bool:
+    """Match a canonical quiet-mode-ON phrase via word-boundary regex."""
+    norm = text.lower().strip().rstrip(".,!?;:")
+    return any(
+        re.search(r"\b" + re.escape(phrase) + r"\b", norm) is not None
+        for phrase in _CANONICAL_QUIET_ON_PHRASES
+    )
+
+
+def _is_canonical_quiet_off(text: str) -> bool:
+    """Match a canonical quiet-mode-OFF phrase via word-boundary regex."""
+    norm = text.lower().strip().rstrip(".,!?;:")
+    return any(
+        re.search(r"\b" + re.escape(phrase) + r"\b", norm) is not None
+        for phrase in _CANONICAL_QUIET_OFF_PHRASES
+    )
 
 
 def _is_canonical_greeting(text: str) -> bool:
@@ -712,6 +803,36 @@ class IntentParser:
                 language=language,
             )
 
+        # Quiet-mode fast-paths: OFF must be checked before ON so that
+        # "wieder reden" doesn't partially match a quiet-on phrase.
+        if _is_canonical_quiet_off(text_lower):
+            path_label = "quiet-off-fast"
+            logger.debug(
+                f"IntentParser: text={text!r} language={language}"
+                f" → intent=quiet_mode_off (path={path_label})"
+            )
+            return IntentResult(
+                intent=Intent.QUIET_MODE_OFF,
+                confidence=0.90,
+                params={"action": "off"},
+                original_text=text,
+                language=language,
+            )
+
+        if _is_canonical_quiet_on(text_lower):
+            path_label = "quiet-on-fast"
+            logger.debug(
+                f"IntentParser: text={text!r} language={language}"
+                f" → intent=quiet_mode_on (path={path_label})"
+            )
+            return IntentResult(
+                intent=Intent.QUIET_MODE_ON,
+                confidence=0.90,
+                params={"action": "on"},
+                original_text=text,
+                language=language,
+            )
+
         # Check each intent category
         best_intent = Intent.CHAT
         best_confidence = 0.0
@@ -719,6 +840,8 @@ class IntentParser:
 
         for intent in [
             Intent.SYSTEM,
+            Intent.QUIET_MODE_OFF,
+            Intent.QUIET_MODE_ON,
             Intent.MORNING_BRIEFING,
             Intent.GREETING,
             Intent.PC_CONTROL,
@@ -825,7 +948,10 @@ class IntentParser:
             Intent.CALENDAR_UPDATE,
             Intent.CALENDAR_DELETE,
         )
-        if intent in (Intent.EMAIL_READ, Intent.EMAIL_SEARCH, Intent.EMAIL_COMPOSE):
+        _QUIET_MODE_INTENT_BASE = 0.85
+        if intent in (Intent.QUIET_MODE_ON, Intent.QUIET_MODE_OFF):
+            confidence = min(1.0, _QUIET_MODE_INTENT_BASE + (match_count * 0.05))
+        elif intent in (Intent.EMAIL_READ, Intent.EMAIL_SEARCH, Intent.EMAIL_COMPOSE):
             confidence = min(1.0, _EMAIL_INTENT_BASE + (match_count * 0.1))
         elif intent in _SPOTIFY_INTENTS:
             confidence = min(1.0, _SPOTIFY_INTENT_BASE + (match_count * 0.1))
@@ -841,7 +967,11 @@ class IntentParser:
             confidence = min(1.0, 0.4 + (match_count * 0.2))
 
         # Extract parameters based on intent
-        if intent == Intent.PC_CONTROL:
+        if intent == Intent.QUIET_MODE_ON:
+            params = {"action": "on"}
+        elif intent == Intent.QUIET_MODE_OFF:
+            params = {"action": "off"}
+        elif intent == Intent.PC_CONTROL:
             params = self._extract_pc_params(text)
         elif intent == Intent.SMART_HOME:
             params = self._extract_smart_home_params(text)

--- a/src/brain/narration_queue.py
+++ b/src/brain/narration_queue.py
@@ -24,6 +24,7 @@ Phase 2 additions on top of the minimal Phase 1 queue:
 from __future__ import annotations
 
 import asyncio
+import collections
 import time
 import uuid
 from collections import deque
@@ -152,6 +153,9 @@ class NarrationQueue:
         # Per-source status tracking (for activity_panel WS broadcast)
         self._source_statuses: dict[str, SourceStatus] = {}
 
+        # History ring-buffer: newest-first, capped at 50 items.
+        self._history: collections.deque[NarrationItem] = collections.deque(maxlen=50)
+
     # -----------------------------------------------------------------------
     # Quiet mode
     # -----------------------------------------------------------------------
@@ -238,16 +242,29 @@ class NarrationQueue:
         asyncio.ensure_future(self._fire_mutation())
         return prior
 
-    def get_source_statuses(self) -> list[dict[str, Any]]:
-        """Return all known source statuses as a list of serialisable dicts."""
-        return [
-            {
-                "source": s.source,
+    def get_source_statuses(self) -> dict[str, dict[str, Any]]:
+        """Return all known source statuses, keyed by source name."""
+        return {
+            s.source: {
                 "status": s.status,
                 "message": s.message,
-                "updatedAt": datetime.fromtimestamp(s.updated_at, tz=timezone.utc).isoformat(),
+                "updated_at": datetime.fromtimestamp(s.updated_at, tz=timezone.utc).isoformat(),
             }
             for s in self._source_statuses.values()
+        }
+
+    def get_history(self) -> list[dict[str, Any]]:
+        """Return the narration history (newest first, max 50) as serialisable dicts."""
+        return [
+            {
+                "id": it.id,
+                "text": it.text,
+                "severity": it.severity,
+                "source": it.source,
+                "created_at": datetime.fromtimestamp(it.created_at, tz=timezone.utc).isoformat(),
+                "ttl_seconds": it.ttl_seconds if it.ttl_seconds > 0 else None,
+            }
+            for it in self._history
         ]
 
     # -----------------------------------------------------------------------
@@ -265,7 +282,7 @@ class NarrationQueue:
                 "text": it.text,
                 "severity": it.severity,
                 "source": it.source,
-                "createdAt": datetime.fromtimestamp(
+                "created_at": datetime.fromtimestamp(
                     it.created_at, tz=timezone.utc
                 ).isoformat(),
                 "channels": it.channels,
@@ -275,7 +292,7 @@ class NarrationQueue:
         qu = self.quiet_until
         return {
             "state": self._sm.state.value,
-            "quietUntil": qu.isoformat() if qu is not None else None,
+            "quiet_until": qu.isoformat() if qu is not None else None,
             "items": items,
         }
 
@@ -468,6 +485,7 @@ class NarrationQueue:
 
         # Completion batching — route into coalesce buffer, not main queue.
         if severity == "completion":
+            self._history.appendleft(item)
             self._accept_completion(item)
             logger.debug(
                 f"NarrationQueue: [{severity}] {item.id!r} → completion batch buffer"
@@ -477,6 +495,7 @@ class NarrationQueue:
             return item_id
 
         # Standard queue insertion.
+        self._history.appendleft(item)
         if severity == "urgent":
             self._queue.appendleft(item)
         else:

--- a/src/brain/narration_queue.py
+++ b/src/brain/narration_queue.py
@@ -1,10 +1,24 @@
-"""Minimal NarrationQueue for JARVIS — Phase 1 (#93).
+"""NarrationQueue for JARVIS — Phase 2 (#93).
 
 Accepts background narration items (from agents, the briefing pipeline, etc.)
 and drains them to TTS only when the conversation state machine is idle.
-Urgent items jump to the front of the queue but still wait for any current
-TTS to finish before emitting (sentence-boundary pre-emption is deferred to
-#93 Phase 2).
+
+Phase 2 additions on top of the minimal Phase 1 queue:
+  - Quiet mode: ``quiet_until`` timestamp; demotes all items to HUD-only
+    except ``urgent`` (which still plays voice but with a soft pre-roll).
+  - Per-source rate limiting: deque-of-timestamps per source, default 6/60s.
+    Excess items are dropped with a WARN log; one ``urgent`` throttle notice
+    fires per throttle event (the notice itself is exempt from rate limiting).
+  - Completion batching: when a ``completion`` item arrives, a 10s coalesce
+    window is opened. Additional ``completion`` items from the same source
+    arriving within that window are merged into one composed utterance.
+  - Channel routing: ``info`` → HUD only; ``update`` → HUD + optional voice;
+    ``urgent`` → voice + HUD; ``completion`` → voice + HUD (batched).
+  - TTL handling: items expired while waiting for idle are dropped from voice
+    but the HUD card was already shown at enqueue time.
+  - WS broadcast callbacks: ``on_queue_mutation`` is called after every queue
+    change so the WS layer can broadcast ``narration_state`` and
+    ``activity_panel`` messages to the frontend.
 """
 
 from __future__ import annotations
@@ -14,7 +28,8 @@ import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Literal
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Literal
 
 from brain.conversation_state import ConversationState, ConversationStateMachine
 from utils.logger import get_logger
@@ -26,17 +41,36 @@ _INFO_TTL_S: float = 120.0
 # No TTL for update/urgent/completion items by default (0 = never expires).
 _NO_TTL: float = 0.0
 
+# Pre-emption pre-roll phrases indexed by severity-context.
+_PREROLL_URGENT_QUIET = "Verzeihung, Sir — kurz: "
+_PREROLL_URGENT_DIALOGUE = "Verzeihung der Unterbrechung, Sir — wichtiger Hinweis: "
+_PREROLL_URGENT_QUIET_MODE = "Sir — "
+
+SeverityLiteral = Literal["info", "update", "urgent", "completion"]
+
 
 @dataclass
 class NarrationItem:
-    """A single item destined for voice narration."""
+    """A single item destined for voice narration and/or HUD display."""
 
     id: str
     text: str
-    severity: Literal["info", "update", "urgent", "completion"] = "update"
+    severity: SeverityLiteral = "update"
     source: str | None = None
     created_at: float = field(default_factory=time.time)
     ttl_seconds: float = _NO_TTL
+    # Channels resolved at enqueue time and updated after quiet-mode check.
+    channels: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SourceStatus:
+    """Per-source status last set via ``jarvis_set_status``."""
+
+    source: str
+    status: Literal["starting", "in_progress", "done", "blocked"]
+    message: str | None
+    updated_at: float = field(default_factory=time.time)
 
 
 class NarrationQueue:
@@ -47,12 +81,24 @@ class NarrationQueue:
 
     Only one item is emitted at a time — the drainer awaits the tts_emit
     callback before popping the next item.
+
+    Phase 2 features: quiet mode, per-source rate limiting, completion
+    batching, channel-aware routing, WS mutation callbacks.
     """
 
     def __init__(
         self,
         state_machine: ConversationStateMachine,
         tts_emit: Callable[[str], Awaitable[None]],
+        # Phase 2: config values (with defaults matching spec)
+        update_voice: bool = False,
+        urgent_max_wait_seconds: float = 30.0,
+        completion_batch_seconds: float = 10.0,
+        rate_limit_items: int = 6,
+        rate_limit_window_seconds: float = 60.0,
+        quiet_mode_default_minutes: int = 60,
+        # Phase 2: WS broadcast callbacks (injected by ws_server)
+        on_queue_mutation: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         """Initialise the queue.
 
@@ -61,13 +107,315 @@ class NarrationQueue:
                 emission (only emit when state is IDLE).
             tts_emit: Async callable that accepts a plain text string and
                 synthesises + broadcasts it through the TTS pipeline.
+            update_voice: When True, ``update``-severity items play voice
+                in addition to HUD. Default False.
+            urgent_max_wait_seconds: How long (seconds) an ``urgent`` item
+                waits for idle before firing anyway with a polite pre-roll.
+            completion_batch_seconds: Coalesce window (seconds) for batching
+                ``completion`` items from the same source.
+            rate_limit_items: Maximum items per source within the window.
+            rate_limit_window_seconds: Rate-limit time window in seconds.
+            quiet_mode_default_minutes: Default quiet mode duration (minutes)
+                when no explicit duration is given to ``set_quiet_mode``.
+            on_queue_mutation: Optional async callback fired after every queue
+                mutation (enqueue / dequeue / quiet toggle / status update).
+                Used by the WS layer to trigger narration_state broadcasts.
         """
         self._sm = state_machine
         self._tts_emit = tts_emit
+        self._update_voice = update_voice
+        self._urgent_max_wait = urgent_max_wait_seconds
+        self._completion_batch_s = completion_batch_seconds
+        self._rate_limit_items = rate_limit_items
+        self._rate_limit_window = rate_limit_window_seconds
+        self._quiet_mode_default_minutes = quiet_mode_default_minutes
+        self._on_queue_mutation = on_queue_mutation
+
         self._queue: deque[NarrationItem] = deque()
         self._wake_event: asyncio.Event = asyncio.Event()
         self._drainer_task: asyncio.Task[None] | None = None
         self._running: bool = False
+
+        # Quiet mode
+        self._quiet_until: datetime | None = None
+
+        # Per-source rate limiting: source → deque of enqueue timestamps
+        self._rate_timestamps: dict[str, deque[float]] = {}
+        # Track sources that already received a throttle notice in the current
+        # window so we don't flood them with repeated urgent throttle items.
+        self._throttle_notified: set[str] = set()
+
+        # Completion batching: source → (batch_items, expiry_task)
+        self._completion_batches: dict[str, list[NarrationItem]] = {}
+        self._completion_batch_tasks: dict[str, asyncio.Task[None]] = {}
+
+        # Per-source status tracking (for activity_panel WS broadcast)
+        self._source_statuses: dict[str, SourceStatus] = {}
+
+    # -----------------------------------------------------------------------
+    # Quiet mode
+    # -----------------------------------------------------------------------
+
+    def set_quiet_mode(
+        self,
+        enabled: bool,
+        duration_minutes: int | None = None,
+    ) -> datetime | None:
+        """Enable or disable quiet mode.
+
+        When enabling while already quiet the timer is replaced (not stacked).
+        Idempotent: disabling while already not quiet is a no-op.
+
+        Args:
+            enabled: True to enter quiet mode, False to leave it.
+            duration_minutes: Duration in minutes. Uses the configured default
+                when None and enabled=True.
+
+        Returns:
+            The new ``quiet_until`` datetime (UTC), or None when disabled.
+        """
+        if enabled:
+            mins = duration_minutes if duration_minutes is not None else self._quiet_mode_default_minutes
+            self._quiet_until = datetime.fromtimestamp(
+                time.time() + mins * 60, tz=timezone.utc
+            )
+            logger.info(f"NarrationQueue: quiet mode ON until {self._quiet_until.isoformat()}")
+        else:
+            self._quiet_until = None
+            logger.info("NarrationQueue: quiet mode OFF")
+        asyncio.ensure_future(self._fire_mutation())
+        return self._quiet_until
+
+    @property
+    def is_quiet(self) -> bool:
+        """Return True when quiet mode is currently active."""
+        if self._quiet_until is None:
+            return False
+        if datetime.now(timezone.utc) >= self._quiet_until:
+            # Expired — clear lazily
+            self._quiet_until = None
+            return False
+        return True
+
+    @property
+    def quiet_until(self) -> datetime | None:
+        """Return the quiet-mode expiry (UTC) or None."""
+        if self._quiet_until is None:
+            return None
+        if datetime.now(timezone.utc) >= self._quiet_until:
+            self._quiet_until = None
+        return self._quiet_until
+
+    # -----------------------------------------------------------------------
+    # Status tracking (jarvis_set_status)
+    # -----------------------------------------------------------------------
+
+    def set_source_status(
+        self,
+        source: str,
+        status: Literal["starting", "in_progress", "done", "blocked"],
+        message: str | None = None,
+    ) -> SourceStatus | None:
+        """Coalesce per-source progress status.
+
+        Replaces any prior status from the same source.
+
+        Args:
+            source: Source identifier (e.g. ``"claude-code-91"``).
+            status: One of ``starting``, ``in_progress``, ``done``, ``blocked``.
+            message: Optional human-readable status message.
+
+        Returns:
+            The prior :class:`SourceStatus` for this source, or None.
+        """
+        prior = self._source_statuses.get(source)
+        self._source_statuses[source] = SourceStatus(
+            source=source,
+            status=status,
+            message=message,
+        )
+        logger.debug(f"NarrationQueue: source status [{source}] → {status!r}")
+        asyncio.ensure_future(self._fire_mutation())
+        return prior
+
+    def get_source_statuses(self) -> list[dict[str, Any]]:
+        """Return all known source statuses as a list of serialisable dicts."""
+        return [
+            {
+                "source": s.source,
+                "status": s.status,
+                "message": s.message,
+                "updatedAt": datetime.fromtimestamp(s.updated_at, tz=timezone.utc).isoformat(),
+            }
+            for s in self._source_statuses.values()
+        ]
+
+    # -----------------------------------------------------------------------
+    # Queue state snapshot (for WS broadcast)
+    # -----------------------------------------------------------------------
+
+    def get_state_snapshot(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of the queue state.
+
+        Used by the WS layer to build the ``narration_state`` broadcast payload.
+        """
+        items = [
+            {
+                "id": it.id,
+                "text": it.text,
+                "severity": it.severity,
+                "source": it.source,
+                "createdAt": datetime.fromtimestamp(
+                    it.created_at, tz=timezone.utc
+                ).isoformat(),
+                "channels": it.channels,
+            }
+            for it in self._queue
+        ]
+        qu = self.quiet_until
+        return {
+            "state": self._sm.state.value,
+            "quietUntil": qu.isoformat() if qu is not None else None,
+            "items": items,
+        }
+
+    # -----------------------------------------------------------------------
+    # Rate limiting (internal)
+    # -----------------------------------------------------------------------
+
+    def _check_rate_limit(self, source: str) -> bool:
+        """Return True when the item may be enqueued; False when throttled.
+
+        Maintains a sliding deque of enqueue timestamps per source. If the
+        deque already holds ``rate_limit_items`` within the window, the item
+        is rejected. A single ``urgent`` throttle notice is enqueued (exempt
+        from rate limiting itself) the first time a source is throttled.
+
+        Args:
+            source: The item's source tag.
+
+        Returns:
+            True if allowed, False if throttled.
+        """
+        now = time.time()
+        window_start = now - self._rate_limit_window
+
+        if source not in self._rate_timestamps:
+            self._rate_timestamps[source] = deque()
+        ts_deque = self._rate_timestamps[source]
+
+        # Evict timestamps outside the window.
+        while ts_deque and ts_deque[0] < window_start:
+            ts_deque.popleft()
+
+        if len(ts_deque) >= self._rate_limit_items:
+            # Throttled — fire one urgent notice if not already done.
+            if source not in self._throttle_notified:
+                self._throttle_notified.add(source)
+                logger.warning(
+                    f"NarrationQueue: source {source!r} throttled "
+                    f"({self._rate_limit_items} items/{self._rate_limit_window:.0f}s)"
+                )
+                # Enqueue a throttle notice exempt from rate limiting.
+                notice = NarrationItem(
+                    id=f"narr-throttle-{uuid.uuid4().hex[:8]}",
+                    text=f"Quelle {source} ist gedrosselt.",
+                    severity="urgent",
+                    source=source,
+                    created_at=time.time(),
+                    ttl_seconds=_NO_TTL,
+                    channels=["voice", "hud"],
+                )
+                self._queue.appendleft(notice)
+                self._wake_event.set()
+                asyncio.ensure_future(self._fire_mutation())
+            return False
+
+        # Within limit — record this timestamp.
+        ts_deque.append(now)
+        # Reset throttle-notice sentinel when the source recovers.
+        self._throttle_notified.discard(source)
+        return True
+
+    # -----------------------------------------------------------------------
+    # Completion batching (internal)
+    # -----------------------------------------------------------------------
+
+    def _accept_completion(self, item: NarrationItem) -> bool:
+        """Route a ``completion`` item into the coalesce buffer.
+
+        Opens (or extends) a 10s coalesce window per source. Returns True
+        to indicate the item was accepted into the buffer (not the main queue).
+
+        Args:
+            item: The ``completion`` NarrationItem to batch.
+
+        Returns:
+            Always True — the item is held in the batch buffer.
+        """
+        src = item.source or "__default__"
+        if src not in self._completion_batches:
+            self._completion_batches[src] = []
+        self._completion_batches[src].append(item)
+
+        # Cancel the previous flush task (if any) to extend the window.
+        existing = self._completion_batch_tasks.get(src)
+        if existing is not None and not existing.done():
+            existing.cancel()
+
+        task = asyncio.ensure_future(self._flush_completion_batch_after(src))
+        self._completion_batch_tasks[src] = task
+        return True
+
+    async def _flush_completion_batch_after(self, source: str) -> None:
+        """Wait for the coalesce window then flush the batch to the main queue.
+
+        Args:
+            source: The source key whose batch window just closed.
+        """
+        try:
+            await asyncio.sleep(self._completion_batch_s)
+        except asyncio.CancelledError:
+            return  # Window extended — new task will flush later.
+
+        batch = self._completion_batches.pop(source, [])
+        self._completion_batch_tasks.pop(source, None)
+        if not batch:
+            return
+
+        if len(batch) == 1:
+            composed_text = batch[0].text
+        else:
+            composed_text = " ".join(it.text for it in batch)
+
+        composed = NarrationItem(
+            id=f"narr-batch-{uuid.uuid4().hex[:8]}",
+            text=composed_text,
+            severity="completion",
+            source=batch[0].source,
+            created_at=time.time(),
+            ttl_seconds=_NO_TTL,
+            channels=["voice", "hud"],
+        )
+        self._queue.append(composed)
+        logger.debug(
+            f"NarrationQueue: completion batch flushed for source={source!r} "
+            f"({len(batch)} item(s)) → {composed.id!r}"
+        )
+        self._wake_event.set()
+        asyncio.ensure_future(self._fire_mutation())
+
+    # -----------------------------------------------------------------------
+    # Mutation callback
+    # -----------------------------------------------------------------------
+
+    async def _fire_mutation(self) -> None:
+        """Call the on_queue_mutation callback if set; silently skip on error."""
+        if self._on_queue_mutation is not None:
+            try:
+                await self._on_queue_mutation()
+            except Exception as exc:
+                logger.warning(f"NarrationQueue: on_queue_mutation callback error: {exc}")
 
     # -----------------------------------------------------------------------
     # Public API
@@ -76,45 +424,77 @@ class NarrationQueue:
     def enqueue(
         self,
         text: str,
-        severity: Literal["info", "update", "urgent", "completion"] = "update",
+        severity: SeverityLiteral = "update",
         source: str | None = None,
         ttl_seconds: float = _NO_TTL,
     ) -> str:
         """Add a narration item to the queue.
 
+        Applies rate limiting (per source), completion batching, and channel
+        routing before inserting into the priority queue.
+
         Args:
             text: Plain-text string for TTS synthesis.
             severity: Priority level; ``urgent`` inserts at the front.
-            source: Optional source tag for logging / deduplication.
+            source: Optional source tag for rate limiting / batching.
             ttl_seconds: Seconds after creation before the item is silently
                 dropped. 0 means never expires.
 
         Returns:
             The generated item id.
         """
+        item_id = f"narr-{uuid.uuid4().hex[:8]}"
+
+        # Rate limiting (skip for system-generated throttle notices).
+        if source is not None:
+            if not self._check_rate_limit(source):
+                logger.warning(
+                    f"NarrationQueue: item from source={source!r} dropped (rate limited)"
+                )
+                return item_id
+
+        # Resolve channels based on severity and quiet mode.
+        channels = self._resolve_channels(severity)
+
         item = NarrationItem(
-            id=f"narr-{uuid.uuid4().hex[:8]}",
+            id=item_id,
             text=text,
             severity=severity,
             source=source,
             created_at=time.time(),
             ttl_seconds=ttl_seconds if ttl_seconds > 0 else _NO_TTL,
+            channels=channels,
         )
+
+        # Completion batching — route into coalesce buffer, not main queue.
+        if severity == "completion":
+            self._accept_completion(item)
+            logger.debug(
+                f"NarrationQueue: [{severity}] {item.id!r} → completion batch buffer"
+                + (f" source={source!r}" if source else "")
+            )
+            asyncio.ensure_future(self._fire_mutation())
+            return item_id
+
+        # Standard queue insertion.
         if severity == "urgent":
             self._queue.appendleft(item)
         else:
             self._queue.append(item)
+
         logger.debug(
             f"NarrationQueue enqueued [{item.severity}] {item.id!r}"
             + (f" source={source!r}" if source else "")
+            + f" channels={channels}"
         )
         self._wake_event.set()
-        return item.id
+        asyncio.ensure_future(self._fire_mutation())
+        return item_id
 
     def speak_now(
         self,
         text: str,
-        severity: Literal["info", "update", "urgent", "completion"] = "update",
+        severity: SeverityLiteral = "update",
         source: str | None = None,
         ttl_seconds: float = _NO_TTL,
     ) -> str:
@@ -144,7 +524,56 @@ class NarrationQueue:
         self._running = False
         if self._drainer_task is not None and not self._drainer_task.done():
             self._drainer_task.cancel()
+        # Cancel any pending completion batch flush tasks.
+        for task in self._completion_batch_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._completion_batch_tasks.clear()
         logger.info("NarrationQueue drainer stopped")
+
+    # -----------------------------------------------------------------------
+    # Channel routing
+    # -----------------------------------------------------------------------
+
+    def _resolve_channels(self, severity: SeverityLiteral) -> list[str]:
+        """Resolve the delivery channels for a given severity and quiet state.
+
+        Channel routing rules:
+          - ``info`` → HUD card only (no voice, even outside quiet mode).
+          - ``update`` → HUD + voice only if ``update_voice`` config is True;
+            in quiet mode voice is suppressed.
+          - ``urgent`` → voice + HUD; in quiet mode voice fires with soft pre-roll.
+          - ``completion`` → voice + HUD; in quiet mode voice is suppressed.
+
+        Quiet mode demotes all but ``urgent`` to HUD-only.
+
+        Args:
+            severity: Item severity string.
+
+        Returns:
+            List of channel strings, e.g. ``["hud"]`` or ``["voice", "hud"]``.
+        """
+        quiet = self.is_quiet
+
+        if severity == "info":
+            return ["hud"]
+
+        if severity == "update":
+            if quiet:
+                return ["hud"]
+            return ["voice", "hud"] if self._update_voice else ["hud"]
+
+        if severity == "urgent":
+            # Urgent always fires voice, even in quiet mode (spec: fires with
+            # softer pre-roll).
+            return ["voice", "hud"]
+
+        if severity == "completion":
+            if quiet:
+                return ["hud"]
+            return ["voice", "hud"]
+
+        return ["hud"]
 
     # -----------------------------------------------------------------------
     # Drainer
@@ -163,29 +592,60 @@ class NarrationQueue:
 
                 item = self._queue[0]
 
-                # TTL check: drop expired items silently.
+                # TTL check: drop expired items silently (HUD already shown).
                 if item.ttl_seconds > 0 and (time.time() - item.created_at) > item.ttl_seconds:
                     self._queue.popleft()
-                    logger.debug(f"NarrationQueue dropped expired item {item.id!r}")
+                    logger.debug(
+                        f"NarrationQueue dropped expired item {item.id!r} "
+                        f"(TTL={item.ttl_seconds:.0f}s)"
+                    )
                     continue
 
-                # Urgent items wait for SPEAKING to finish (max 30 s).
-                # Info/update/completion all wait for IDLE unconditionally.
+                # Re-resolve channels at drain time (quiet mode may have
+                # changed since the item was enqueued).
+                item.channels = self._resolve_channels(item.severity)
+
+                # Determine whether voice delivery is wanted.
+                wants_voice = "voice" in item.channels
+
+                if not wants_voice:
+                    # HUD-only item: pop and continue (HUD was already shown at
+                    # enqueue via the mutation broadcast).
+                    self._queue.popleft()
+                    logger.debug(
+                        f"NarrationQueue: [{item.severity}] {item.id!r} HUD-only, skipping TTS"
+                    )
+                    continue
+
+                # State-gated voice delivery.
                 if self._sm.state == ConversationState.IDLE:
                     pass  # ready to emit
-                elif item.severity == "urgent" and self._sm.state == ConversationState.SPEAKING:
-                    # Wait up to 30 s for current TTS to finish.
-                    reached_idle = await self._sm.wait_for_idle(timeout=30.0)
+                elif item.severity == "urgent":
+                    # Urgent: wait up to urgent_max_wait_seconds for idle;
+                    # if active_dialogue is still running after that, fire anyway.
+                    reached_idle = await self._sm.wait_for_idle(
+                        timeout=self._urgent_max_wait
+                    )
                     if not reached_idle:
                         logger.warning(
-                            f"Urgent item {item.id!r} waited 30 s for idle — emitting anyway"
+                            f"Urgent item {item.id!r} waited {self._urgent_max_wait:.0f}s "
+                            "for idle — emitting with polite pre-roll"
                         )
+                        # Apply the more polite long pre-roll for dialogue interruption.
+                        item.text = _PREROLL_URGENT_DIALOGUE + item.text
+                    # If we are in quiet mode now, use the soft pre-roll.
+                    elif self.is_quiet:
+                        item.text = _PREROLL_URGENT_QUIET_MODE + item.text
+                    else:
+                        item.text = _PREROLL_URGENT_QUIET + item.text
                 else:
-                    # Wait indefinitely for idle.
+                    # info/update/completion wait indefinitely.
+                    # If TTL expires while waiting, the item will be dropped on
+                    # next iteration.
                     await self._sm.wait_for_idle(timeout=None)
                     continue  # re-evaluate queue head after waking
 
-                # Re-check queue (may have been emptied by stop() or concurrent code).
+                # Re-check queue (may have been emptied concurrently).
                 if not self._queue:
                     continue
 
@@ -193,7 +653,19 @@ class NarrationQueue:
 
                 # Re-check TTL after potentially long wait.
                 if item.ttl_seconds > 0 and (time.time() - item.created_at) > item.ttl_seconds:
-                    logger.debug(f"NarrationQueue dropped expired item {item.id!r} (post-wait)")
+                    logger.debug(
+                        f"NarrationQueue dropped expired item {item.id!r} (post-wait)"
+                    )
+                    # HUD card already shown; skip voice only.
+                    continue
+
+                # Re-resolve channels one last time after any waits.
+                item.channels = self._resolve_channels(item.severity)
+                if "voice" not in item.channels:
+                    logger.debug(
+                        f"NarrationQueue: [{item.severity}] {item.id!r} "
+                        "demoted to HUD-only after wait (quiet mode engaged)"
+                    )
                     continue
 
                 logger.debug(f"NarrationQueue emitting [{item.severity}] {item.id!r}")
@@ -201,10 +673,6 @@ class NarrationQueue:
                     await self._tts_emit(item.text)
                 except Exception as exc:
                     logger.warning(f"NarrationQueue tts_emit failed for {item.id!r}: {exc}")
-
-                # After emitting, loop immediately so chained items don't
-                # insert an artificial pause beyond the state-machine's own
-                # TTS silence buffer (500 ms).
 
         except asyncio.CancelledError:
             logger.debug("NarrationQueue drain_loop cancelled cleanly")

--- a/src/brain/orchestrator.py
+++ b/src/brain/orchestrator.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 from brain.agents.base import AgentResult, BaseAgent
 from brain.agents.chat_agent import ChatAgent
 from brain.agents.morning_briefing_agent import build_briefing_prompt
+from brain.agents.quiet_mode_agent import QuietModeAgent
 from brain.agents.search_agent import SearchAgent
 from brain.agents.system_agent import SystemAgent
 from brain.claude_client import ClaudeClient
@@ -81,12 +82,15 @@ class OrchestratorDecision:
 # voice-change, and memory-reset — none of which have MCP equivalents.
 # Spotify intents (SEARCH, QUEUE, PLAY_CONTEXT, and all transport intents)
 # fall through to OpenClaw, which calls the spotify_* MCP tools (issue #87).
+# QUIET_MODE_ON / QUIET_MODE_OFF are handled locally by QuietModeAgent (#93).
 _LOCAL_INTENTS: frozenset[Intent] = frozenset(
     {
         Intent.SYSTEM,
         Intent.WEB_SEARCH,
         Intent.GREETING,
         Intent.MORNING_BRIEFING,
+        Intent.QUIET_MODE_ON,
+        Intent.QUIET_MODE_OFF,
     }
 )
 
@@ -162,6 +166,7 @@ class Orchestrator:
         now fall through to OpenClaw → MCP tools (issue #76).
         SpotifyAgent is removed: all Spotify intents now fall through to
         OpenClaw → spotify_* MCP tools (issue #87).
+        QuietModeAgent handles QUIET_MODE_ON / QUIET_MODE_OFF (#93 Phase 2).
         """
         self._agents = {
             "chat": ChatAgent(self.claude_client),
@@ -169,6 +174,7 @@ class Orchestrator:
             "system": SystemAgent(
                 self.claude_client, memory=None, tts_engine=self.tts_engine
             ),
+            "quiet_mode": QuietModeAgent(self._narration_queue),
         }
 
     def set_tts_engine(self, tts_engine: Any) -> None:
@@ -842,9 +848,12 @@ def _intent_to_agent_name(intent: Intent) -> str:
     (issue #76 for PC/home, issue #87 for Spotify).
     GREETING is not mapped here — it is handled by ``_handle_greeting`` in the
     orchestrator directly (may fall through to chat).
+    QUIET_MODE_ON / QUIET_MODE_OFF route to the QuietModeAgent (#93 Phase 2).
     """
     if intent == Intent.SYSTEM:
         return "system"
     if intent == Intent.WEB_SEARCH:
         return "search"
+    if intent in (Intent.QUIET_MODE_ON, Intent.QUIET_MODE_OFF):
+        return "quiet_mode"
     return "chat"


### PR DESCRIPTION
## Summary
Phase 2 of #93 — extends the Phase-1 conversational foundation (NarrationQueue + ConversationState) with the **external interfaces** and **HUD surface** needed for background agents (Claude Code, etc.) to push narration items into JARVIS without interrupting the user.

Refs #93. Phase 3 (audio ducking + Spotify SDK ducking + sentence-boundary pre-emption) is left for a follow-up PR.

## Backend additions
- **NarrationQueue extensions** (`src/brain/narration_queue.py`, +522 LOC): quiet mode (`set_quiet_mode(enabled, duration_minutes)`), per-source rate limiting (6 items / 60s default — throttle-notice exempt from itself), completion batching (10s coalesce window per source), severity-based channel routing (`info`→HUD; `update`→HUD+voice if opted in; `urgent`→HUD+voice; `completion`→HUD+voice batched), TTL handling.
- **3 MCP tools** in `src/api/mcp_tools/narration_tools.py`: `jarvis_notify`, `jarvis_set_status`, `jarvis_set_quiet_mode` — registered via the existing `@register_tool` decorator pattern. Verified at runtime: all 3 appear in `_tool_registry`.
- **3 HTTP endpoints** in `ws_server.py`: `POST /api/jarvis/notify` / `/status` / `/quiet`. All 3 verified end-to-end with curl (HTTP 200, correct JSON responses).
- **Voice intents** `INTENT.QUIET_MODE_ON` / `INTENT.QUIET_MODE_OFF` with canonical fast-path: "leise arbeiten", "sei leise", "be quiet" / "wieder reden", "rede wieder", "speak again".
- **`QuietModeAgent`** in `src/brain/agents/quiet_mode_agent.py` wired into orchestrator dispatch.
- **Config block** `narration:` in `config.yaml`.

## Frontend additions
- **New feature** `frontend/src/features/activity/` following the jarvis-feature-scaffold convention. ActivityPanel split into `ActivityQuietBar` + `ActivitySourceList` + `ActivityHistoryList` per the one-component-per-file rule. RTK slice + RTK Query streaming subscription to `narration_state` and `activity_panel` WS messages.
- Slice + panel registered in `app/store.ts` and `app/panels.ts` at slot **R2** (vacated by the briefing panel removal in #91).
- `'activity'` added to the `PanelId` union.

## Verified by automation
- ✅ Backend imports clean (`py_compile` + module import end-to-end with all `@register_tool` decorators firing).
- ✅ All 3 narration tools registered in MCP `_tool_registry` (`jarvis_notify`, `jarvis_set_status`, `jarvis_set_quiet_mode`).
- ✅ All 3 HTTP endpoints return HTTP 200 with correct JSON (curl-tested live):
  - `POST /api/jarvis/notify` → `{"item_id": "narr-...", "queued_at": "...", "channels": ["hud"]}`
  - `POST /api/jarvis/status` → `{"source": "test-curl", "prior_status": null}`
  - `POST /api/jarvis/quiet` → `{"quiet_until": "2026-04-27T18:27:..."}`
- ✅ TypeScript clean for the new code (pre-existing nowplaying test errors are unrelated).
- ✅ Severity routing: `info`→`["hud"]` confirmed in the curl response (matches spec).

## Test plan — pending user manual test
Before merge, the user needs to verify:
- [ ] HUD shows the new Activity panel in slot R2 with severity-colored badges.
- [ ] `curl POST /api/jarvis/notify` items appear in the panel in real-time.
- [ ] Voice command "leise arbeiten" → quiet bar appears at top of Activity panel.
- [ ] Voice command "wieder reden" → quiet bar disappears.
- [ ] Existing flows (briefing, PTT, wake-word) still work — no regressions.

## Phase 3 deferred (TODOs in code)
- `# TODO(#93-P3): sentence-boundary pre-emption for urgent during SPEAKING` — drainer currently lets current TTS finish naturally before firing urgent.
- Audio ducking (Spotify SDK + SFX/chime verify against #30) — entire Phase 3 scope.

## Tests
Deferred per user direction. Reviewer skipped — surface is large but tests would be the right vehicle for end-to-end coverage rather than reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)