### PR TITLE
feat(network): Tailscale remote access (#98)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,23 @@ GITLAB_TOKEN=
 # Platform override (optional — auto-detected)
 # ------------------------------------------------------------------------------
 # JARVIS_PLATFORM=rpi
+
+# ------------------------------------------------------------------------------
+# Tailscale Remote Access (optional)
+# When you run JARVIS as a multi-device service over Tailscale:
+# - JARVIS_REMOTE_ACCESS=true flips api.host from 127.0.0.1 to 0.0.0.0 so the
+#   backend listens on the tailnet interface as well as loopback. Tailscale
+#   ACL is your auth boundary — there is no API-level token check yet.
+# - TAILSCALE_HOSTNAME or `tailscale status --json` is auto-detected at
+#   startup to populate mcp.advertise_host. Set explicitly only to override.
+# - JARVIS_MCP_ADVERTISE_HOST is still the highest-priority override.
+# ------------------------------------------------------------------------------
+# JARVIS_REMOTE_ACCESS=true
+# TAILSCALE_HOSTNAME=laptop-paps.tailnet.ts.net
+# JARVIS_MCP_ADVERTISE_HOST=laptop-paps.tailnet.ts.net
+
+# When OpenClaw runs on a different machine than JARVIS, update
+# `openclaw.gateway_url` in config/config.yaml to use the OpenClaw host's
+# tailnet address, e.g.:
+#   gateway_url: "http://linux-laptop.tailnet.ts.net:18789"
+# (config.yaml key — not an env var. Listed here for cross-reference.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,15 +113,19 @@ curl -s -X POST http://127.0.0.1:8766/api/jarvis/notify \
 - `info` — HUD only, no voice (e.g. background poll ticks).
 - `update` — HUD + soft chime; voice only when `narration.update_voice: true`.
 
-**When to fire (orchestrator default policy):**
+**Default rule (hard): every user-facing status update from the orchestrator is paired with a `jarvis_notify`.** Whenever the orchestrator writes a status message to the user — work started on a task, work finished, blocker hit, decision needed, subagent returned, build/test green/red, PR opened, merge complete, branch synced — the same content also goes out via `jarvis_notify` so JARVIS speaks it. The user wants to *hear* the status, not only see it in the chat. The 10 s `completion` batching by `source` already deduplicates near-simultaneous fires, so the orchestrator does not hand-batch.
+
+**When to fire (concrete triggers):**
+- Any message to the user that is a status report (started / finished / blocked / decision-needed).
 - User explicitly asks to be notified ("sag mir Bescheid wenn fertig", "melde dich wenn der Subagent zurück ist").
-- Long-running background subagent (>2 min) returns and the user is genuinely waiting.
-- Major workflow milestones the user wants reported (PR opened, merge complete, build/test green/red).
+- Subagent returns (especially long-running background ones) and the user has been waiting on the result.
+- Major workflow milestones (PR opened, merge complete, build/test green/red, deployment finished).
 
 **When NOT to fire:**
-- Trivial sub-second steps. Don't narrate every file edit.
-- The user is actively in the chat and will see the next response immediately.
-- The user has not asked to be told and the work was their direct request (they're already watching).
+- **Batch / intermediate steps inside one larger operation** — fire only on the final completion or on a real change of state, not on every micro-progress line.
+- Direct conversational answers (questions, explanations, code walk-throughs) that are not status updates.
+- Pure passthrough of subagent output that the user is actively reading in the chat at the same moment.
+- Trivial tool-call narration (file read, single grep) — those aren't "status".
 
 **Stable source convention:** use `"claude-code"` for general orchestrator notifications; `"claude-code-<issue-num>"` if you need per-issue separation. Coalescing via the 10 s window means redundant completions collapse cleanly.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -60,7 +60,24 @@ api:
   # Bind address for WS (:8765) and HTTP (:8766) servers.
   # Default is loopback — safe for a personal assistant with no auth layer.
   # Set to "0.0.0.0" only when you need LAN/WAN access AND have added auth.
+  # Env-switch alternative (chosen over a new config key to keep the surface
+  # minimal): set JARVIS_REMOTE_ACCESS=true in .env to flip from 127.0.0.1 to
+  # 0.0.0.0 at startup without touching this file.  Tailscale ACL is then the
+  # auth boundary.  An explicit value here ALWAYS overrides the env switch.
+  # Note: setting `host: "127.0.0.1"` here does NOT prevent `JARVIS_REMOTE_ACCESS=true`
+  # from flipping to 0.0.0.0 — the env switch wins when the config value is the
+  # default loopback.  If you need to enforce loopback regardless of env, ensure
+  # `JARVIS_REMOTE_ACCESS` is unset in the environment, or pin a non-default
+  # loopback alias such as `host: "127.0.0.2"` which will be used verbatim.
   host: "127.0.0.1"
+  # Allowed CORS origins for the HTTP server.  Each entry can be:
+  #   - A literal origin:            "http://localhost:5173"
+  #   - A wildcard (allow all):      "*"
+  #   - An fnmatch-style glob:       "https://*.tailnet.ts.net:5173"
+  # Wildcards supported (fnmatch): "https://*.tailnet.ts.net:5173" matches any
+  # tailnet subdomain on port 5173, e.g. "https://laptop-paps.tailnet.ts.net:5173".
+  # Patterns must include the port for non-default ports — fnmatch's `*` does
+  # not cross `:` boundaries by convention.
   cors_origins: ["http://localhost:5173"]
 
 logging:
@@ -86,8 +103,14 @@ mcp:
   # advertise_host: null means use bind_host for the SSE URL registered with
   # OpenClaw.  Set to a Tailscale IP or MagicDNS hostname (e.g.
   # "laptop-paps.tailnet.ts.net") when OpenClaw must reach this JARVIS instance
-  # over the tailnet from a different machine.  Can also be set via the
-  # JARVIS_MCP_ADVERTISE_HOST environment variable (takes precedence).
+  # over the tailnet from a different machine.
+  # Resolution order (highest priority first):
+  #   1. JARVIS_MCP_ADVERTISE_HOST env var — highest priority override.
+  #   2. This config key (advertise_host) when set and not null.
+  #   3. Auto-detect from TAILSCALE_HOSTNAME env var or `tailscale status --json`
+  #      (parses Self.DNSName; 2-second timeout; silent no-op if Tailscale is
+  #      not installed or the daemon is not running).
+  #   4. bind_host fallback.
   advertise_host: null
   # openclaw_headers: optional HTTP headers forwarded to the OpenClaw MCP
   # registry entry (openclaw mcp set <name> '{"url": "...", "headers": {...}}').

--- a/docker-compose.rpi.yml
+++ b/docker-compose.rpi.yml
@@ -13,5 +13,8 @@ services:
       - /dev/snd:/dev/snd
     environment:
       - JARVIS_PLATFORM=rpi
+      - JARVIS_REMOTE_ACCESS=${JARVIS_REMOTE_ACCESS:-}
+      - TAILSCALE_HOSTNAME=${TAILSCALE_HOSTNAME:-}
+      - JARVIS_MCP_ADVERTISE_HOST=${JARVIS_MCP_ADVERTISE_HOST:-}
     network_mode: host
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,8 @@ services:
       - /dev/snd:/dev/snd
     environment:
       - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
+      - JARVIS_REMOTE_ACCESS=${JARVIS_REMOTE_ACCESS:-}
+      - TAILSCALE_HOSTNAME=${TAILSCALE_HOSTNAME:-}
+      - JARVIS_MCP_ADVERTISE_HOST=${JARVIS_MCP_ADVERTISE_HOST:-}
     network_mode: host
     restart: unless-stopped

--- a/docs/ops/tailscale-setup.md
+++ b/docs/ops/tailscale-setup.md
@@ -1,0 +1,145 @@
+# Tailscale Remote Access Setup
+
+Connect multiple devices to a JARVIS backend running on one host without
+exposing any port to the public internet. Tailscale ACL is the authentication
+boundary — there is no API-level token check in JARVIS today.
+
+---
+
+## Prerequisites
+
+- Tailscale installed and `tailscale up` completed on every device that needs
+  access. Download: https://tailscale.com/download
+- All devices are in the same Tailscale account (tailnet).
+
+---
+
+## Enable on the JARVIS host
+
+1. Add `JARVIS_REMOTE_ACCESS=true` to `.env` on the JARVIS host.
+2. Restart the backend:
+   ```bash
+   PYTHONPATH=src .venv/bin/python -m main
+   # or: docker-compose up --build
+   ```
+3. The log line `API bind host: '0.0.0.0' (source: env-remote-access ...)` confirms
+   the backend is now listening on all interfaces, including the Tailscale interface.
+4. From a peer device on the tailnet:
+   ```bash
+   curl http://<tailscale-host>:8766/health
+   ```
+   Replace `<tailscale-host>` with the Tailscale MagicDNS hostname or IP of the
+   JARVIS machine (visible in `tailscale status`).
+
+---
+
+## MCP advertise host
+
+JARVIS auto-detects the Tailscale hostname at startup so the MCP SSE URL
+advertised to OpenClaw is reachable from remote devices.
+
+Resolution order (highest priority first):
+
+1. `JARVIS_MCP_ADVERTISE_HOST` env var — explicit override.
+2. `mcp.advertise_host` in `config/config.yaml`.
+3. `TAILSCALE_HOSTNAME` env var (fast path — set this when auto-detect is slow).
+4. `tailscale status --json` subprocess (parses `Self.DNSName`; 2-second timeout;
+   silent no-op if Tailscale is not installed).
+5. `mcp.bind_host` fallback.
+
+To override explicitly:
+```bash
+# .env
+TAILSCALE_HOSTNAME=laptop-paps.tailnet.ts.net
+# or
+JARVIS_MCP_ADVERTISE_HOST=laptop-paps.tailnet.ts.net
+```
+
+---
+
+## CORS
+
+The frontend served from a remote device's browser will send an `Origin` header
+that doesn't match `http://localhost:5173`. Add the Tailscale host origin to
+`api.cors_origins` in `config/config.yaml`:
+
+```yaml
+api:
+  cors_origins:
+    - "http://localhost:5173"
+    - "https://laptop-paps.tailnet.ts.net:5173"
+    # Or use a wildcard (fnmatch-style) to cover any tailnet machine:
+    - "https://*.tailnet.ts.net:5173"
+```
+
+Wildcard patterns use `fnmatch.fnmatchcase` — `*` matches any sequence of
+characters within a segment.
+
+> **Note:** the wildcard must include the port. `https://*.tailnet.ts.net`
+> alone will not match `https://laptop.tailnet.ts.net:5173` — fnmatch globs
+> do not span port separators. Always append `:5173` (or whatever port the
+> Vite dev server uses) to the pattern.
+
+---
+
+## OpenClaw remote
+
+When OpenClaw runs on a different machine than JARVIS, point the gateway URL
+at the OpenClaw host's tailnet address:
+
+```yaml
+# config/config.yaml
+openclaw:
+  gateway_url: "http://100.84.x.y:18789"   # tailnet IP of the OpenClaw host
+  gateway_port: 18789                        # same port as on the gateway host
+```
+
+You can also use the MagicDNS hostname: `http://openclaw-host.tailnet.ts.net:18789`.
+
+---
+
+## Multi-device ACL
+
+In the Tailscale admin console (https://login.tailscale.com/admin/acls), restrict
+access to JARVIS's port range to a tagged group of trusted devices only:
+
+```json
+{
+  "acls": [
+    {
+      "action": "accept",
+      "src":    ["tag:trusted-clients"],
+      "dst":    ["tag:jarvis-host:8765-8767"]
+    }
+  ]
+}
+```
+
+See the Tailscale ACL documentation:
+https://tailscale.com/kb/1018/acls
+
+---
+
+## RPi migration
+
+The `docker-compose.rpi.yml` already passes `JARVIS_REMOTE_ACCESS`,
+`TAILSCALE_HOSTNAME`, and `JARVIS_MCP_ADVERTISE_HOST` through from the host
+shell. On the RPi:
+
+1. Set `JARVIS_REMOTE_ACCESS=true` in `.env`.
+2. Run `docker-compose -f docker-compose.rpi.yml up --build`.
+3. Tailscale must be installed and running on the RPi host (not inside the
+   container); `network_mode: host` shares the Tailscale interface.
+
+---
+
+## Troubleshooting
+
+- `tailscale status` shows the MagicDNS `DNSName` column for this machine.
+- If `mcp.advertise_host` resolves to `127.0.0.1` after enabling Tailscale:
+  1. Check backend logs for `Tailscale hostname auto-detected` or
+     `MCP advertise host` log lines.
+  2. Run `tailscale status --json` manually as the JARVIS OS user and confirm
+     it exits 0 and the `Self.DNSName` field is populated.
+  3. If `tailscale` is not in `PATH` for the JARVIS user, set
+     `TAILSCALE_HOSTNAME` explicitly in `.env` as a workaround.

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -8,7 +8,9 @@ and Fish Audio TTS — then streams the MP3 response back to the frontend.
 
 import asyncio
 import base64
+import fnmatch
 import json
+import os
 import socket
 import sys
 import time
@@ -4412,6 +4414,37 @@ async def config_repos_post_handler(request: web.Request) -> web.Response:
 
 
 # ---------------------------------------------------------------------------
+# CORS helpers
+# ---------------------------------------------------------------------------
+
+
+def _origin_allowed(origin: str, patterns: list[str]) -> bool:
+    """Return True when *origin* matches any entry in *patterns*.
+
+    Each pattern can be:
+    - A literal origin string (``"http://localhost:5173"``).
+    - A bare ``"*"`` to allow any origin.
+    - An ``fnmatch``-style glob (``"https://*.tailnet.ts.net"``), matched
+      case-sensitively via ``fnmatch.fnmatchcase``.
+
+    Args:
+        origin: The ``Origin`` header value from the HTTP request.
+        patterns: List of allowed-origin patterns from config.
+
+    Returns:
+        ``True`` if *origin* should be allowed, ``False`` otherwise.
+    """
+    for pattern in patterns:
+        if pattern == "*":
+            return True
+        if pattern == origin:
+            return True
+        if fnmatch.fnmatchcase(origin, pattern):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Server startup
 # ---------------------------------------------------------------------------
 
@@ -4646,11 +4679,31 @@ async def start_ws_server(
     # Server ports, host and CORS
     ws_port = config.get("ws_port", 8765)
     http_port = config.get("http_port", 8766)
-    # Default is loopback — JARVIS is a personal assistant; exposing to 0.0.0.0
-    # with no authentication is a security risk. Override in config.yaml only
-    # if you deliberately want LAN/WAN exposure and have added auth.
-    host = config.get("host", "127.0.0.1")
-    cors_origins = config.get("cors_origins", ["http://localhost:5173"])
+    # Determine effective bind host.  Resolution order:
+    #   1. Explicit value in config.yaml (anything other than the literal default
+    #      "127.0.0.1" counts as an explicit override) — wins unconditionally.
+    #   2. JARVIS_REMOTE_ACCESS env var: when truthy ("1", "true", "yes",
+    #      case-insensitive) AND config has the default loopback value, flip to
+    #      "0.0.0.0" so the backend listens on all interfaces (including the
+    #      Tailscale interface).  Tailscale ACL is then the auth boundary.
+    #      NOTE: we deliberately chose the env-switch path over a new config key
+    #      (api.remote_access_mode: tailscale) to keep the surface minimal.
+    #   3. Fallback: "127.0.0.1".
+    _config_host: str = config.get("host", "127.0.0.1")
+    _remote_access_raw: str = os.environ.get("JARVIS_REMOTE_ACCESS", "").strip().lower()
+    _remote_access_enabled: bool = _remote_access_raw in {"1", "true", "yes"}
+    if _config_host != "127.0.0.1":
+        host = _config_host
+        logger.info(f"API bind host: {host!r} (source: config)")
+    elif _remote_access_enabled:
+        host = "0.0.0.0"
+        logger.info(
+            f"API bind host: {host!r} (source: env-remote-access / JARVIS_REMOTE_ACCESS=true)"
+        )
+    else:
+        host = _config_host
+        logger.info(f"API bind host: {host!r} (source: default)")
+    cors_origins: list[str] = config.get("cors_origins", ["http://localhost:5173"])
 
     # WebSocket application
     ws_app = web.Application()
@@ -4666,7 +4719,7 @@ async def start_ws_server(
             response = await handler(request)
 
         origin = request.headers.get("Origin", "")
-        if origin in cors_origins or "*" in cors_origins:
+        if origin and _origin_allowed(origin, cors_origins):
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
             response.headers["Access-Control-Allow-Headers"] = "Content-Type"

--- a/src/main.py
+++ b/src/main.py
@@ -181,4 +181,16 @@ def publish_event(event_type: str, payload: dict[str, Any] | None = None) -> Non
 
 
 if __name__ == "__main__":
+    # Prime the Tailscale hostname cache before the asyncio loop starts so the
+    # MCP advertise-host resolution inside `start_mcp_server` is a non-blocking
+    # cache hit.  The subprocess is allowed to block here because we are still
+    # in sync startup code, before asyncio.run() is entered.
+    try:
+        from utils.device import resolve_tailscale_hostname as _prime_tailscale
+
+        _prime_tailscale()
+    except Exception as _exc:  # noqa: BLE001
+        # A flaky Tailscale CLI must never prevent startup.
+        logger.debug(f"Tailscale hostname prime failed (non-fatal): {_exc}")
+
     asyncio.run(main())

--- a/src/utils/device.py
+++ b/src/utils/device.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import socket
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,11 @@ logger = get_logger("device")
 _OPENCLAW_DEVICE_FILE = Path.home() / ".openclaw" / "identity" / "device.json"
 _MAX_SLUG_LEN = 40
 _SLUG_FALLBACK = "jarvis"
+
+# Cache for Tailscale hostname lookup — None means "not yet resolved",
+# empty string means "resolved but not found".
+_tailscale_hostname_cache: str | None = None
+_tailscale_hostname_resolved: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -82,13 +88,81 @@ def resolve_device_slug() -> str:
     return slug
 
 
+def resolve_tailscale_hostname() -> str | None:
+    """Detect this machine's Tailscale MagicDNS hostname via ``tailscale status --json``.
+
+    Tries ``TAILSCALE_HOSTNAME`` env var first (cheap path).  Falls back to
+    running the Tailscale CLI with a 2-second timeout and parsing
+    ``Self.DNSName`` from the JSON output.  Strips the trailing dot that
+    Tailscale appends (e.g. ``"laptop-paps.tailnet.ts.net."`` →
+    ``"laptop-paps.tailnet.ts.net"``).
+
+    The result is cached after the first call so subsequent invocations do not
+    re-spawn the subprocess.
+
+    Returns:
+        Tailscale hostname string, or ``None`` when Tailscale is not installed,
+        the daemon is not running, or detection fails for any reason.
+    """
+    global _tailscale_hostname_cache, _tailscale_hostname_resolved
+
+    if _tailscale_hostname_resolved:
+        return _tailscale_hostname_cache or None
+
+    _tailscale_hostname_resolved = True
+
+    # Fast path: explicit env var.
+    env_val = os.environ.get("TAILSCALE_HOSTNAME", "").strip()
+    if env_val:
+        logger.info(f"Tailscale hostname from TAILSCALE_HOSTNAME env var: {env_val!r}")
+        _tailscale_hostname_cache = env_val
+        return env_val
+
+    # Subprocess path: parse `tailscale status --json`.
+    try:
+        result = subprocess.run(
+            ["tailscale", "status", "--json"],
+            timeout=2.0,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            logger.debug(
+                f"tailscale status --json returned code {result.returncode}; "
+                "Tailscale may not be running"
+            )
+            return None
+
+        data = json.loads(result.stdout)
+        dns_name: str = data.get("Self", {}).get("DNSName", "")
+        if dns_name:
+            # Strip trailing dot from FQDN.
+            hostname = dns_name.rstrip(".")
+            logger.info(f"Tailscale hostname auto-detected from CLI: {hostname!r}")
+            _tailscale_hostname_cache = hostname
+            return hostname
+
+        logger.debug("tailscale status --json: Self.DNSName is empty")
+    except FileNotFoundError:
+        logger.debug("tailscale CLI not found; skipping Tailscale hostname detection")
+    except subprocess.TimeoutExpired:
+        logger.debug("tailscale status --json timed out (>2 s); skipping")
+    except json.JSONDecodeError as exc:
+        logger.debug(f"Failed to parse tailscale status JSON: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(f"Unexpected error during Tailscale hostname detection: {exc}")
+
+    return None
+
+
 def resolve_advertise_host(mcp_config: dict[str, Any]) -> str:
     """Return the host to advertise in the MCP SSE URL.
 
     Resolution order:
       1. ``JARVIS_MCP_ADVERTISE_HOST`` env var.
       2. ``mcp_config['advertise_host']`` when set and not null.
-      3. ``mcp_config['bind_host']`` (default ``"127.0.0.1"``).
+      3. ``TAILSCALE_HOSTNAME`` env var or ``tailscale status --json`` (auto-detect).
+      4. ``mcp_config['bind_host']`` (default ``"127.0.0.1"``).
 
     Args:
         mcp_config: The ``mcp`` section from ``config.yaml``.
@@ -105,6 +179,11 @@ def resolve_advertise_host(mcp_config: dict[str, Any]) -> str:
     if config_host:
         logger.debug(f"MCP advertise host from config: {config_host!r}")
         return str(config_host)
+
+    tailscale_host = resolve_tailscale_hostname()
+    if tailscale_host:
+        logger.info(f"MCP advertise host from Tailscale auto-detect: {tailscale_host!r}")
+        return tailscale_host
 
     bind_host: str = mcp_config.get("bind_host", "127.0.0.1")
     logger.debug(f"MCP advertise host defaults to bind_host: {bind_host!r}")

--- a/tests/api/test_ws_server_cors_and_host.py
+++ b/tests/api/test_ws_server_cors_and_host.py
@@ -1,0 +1,215 @@
+"""Unit tests for _origin_allowed() and the host-resolution logic in ws_server.
+
+_origin_allowed is a pure function importable directly.
+
+The host-resolution logic (JARVIS_REMOTE_ACCESS switch) is inlined inside
+start_ws_server and is NOT extracted into a standalone helper.  Rather than
+booting the full server (which pulls Whisper, wake-word, OpenClaw, etc.), we
+test the logic via a thin local re-implementation that mirrors the exact
+three-branch conditional found in ws_server.py.  Any future extraction of that
+logic into a helper should obsolete the local re-implementation here and the
+tests in class TestHostResolution can be pointed at the real helper.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from api.ws_server import _origin_allowed
+
+
+# ===========================================================================
+# Local re-implementation of the host-resolution logic for unit-testing.
+#
+# Source in ws_server.py (lines ~4692-4705):
+#
+#   _config_host = config.get("host", "127.0.0.1")
+#   _remote_access_raw = os.environ.get("JARVIS_REMOTE_ACCESS", "").strip().lower()
+#   _remote_access_enabled = _remote_access_raw in {"1", "true", "yes"}
+#   if _config_host != "127.0.0.1":
+#       host = _config_host
+#   elif _remote_access_enabled:
+#       host = "0.0.0.0"
+#   else:
+#       host = _config_host
+# ===========================================================================
+
+
+def _resolve_host(config_host: str) -> str:
+    """Mirror the host-resolution branch from start_ws_server.
+
+    Reads JARVIS_REMOTE_ACCESS from the real os.environ so that monkeypatch
+    works correctly in tests.  config_host simulates config.get("host", ...).
+    """
+    remote_raw = os.environ.get("JARVIS_REMOTE_ACCESS", "").strip().lower()
+    remote_enabled = remote_raw in {"1", "true", "yes"}
+    if config_host != "127.0.0.1":
+        return config_host
+    if remote_enabled:
+        return "0.0.0.0"
+    return config_host
+
+
+# ===========================================================================
+# _origin_allowed — literal and wildcard matching
+# ===========================================================================
+
+
+class TestOriginAllowed:
+    """Tests for the _origin_allowed(origin, patterns) helper."""
+
+    def test_literal_origin_in_patterns_returns_true(self):
+        """A literal origin that exactly matches a pattern entry is allowed."""
+        assert _origin_allowed("http://localhost:5173", ["http://localhost:5173"]) is True
+
+    def test_literal_origin_not_in_patterns_returns_false(self):
+        """An origin that does not match any pattern is rejected."""
+        assert _origin_allowed("http://evil.example.com", ["http://localhost:5173"]) is False
+
+    def test_wildcard_star_allows_any_origin(self):
+        """A bare '*' pattern allows every origin (regression for existing semantics)."""
+        assert _origin_allowed("https://anything.example.com", ["*"]) is True
+
+    def test_wildcard_star_allows_empty_origin(self):
+        """A bare '*' pattern allows even an empty-string origin."""
+        assert _origin_allowed("", ["*"]) is True
+
+    def test_fnmatch_glob_matches_tailscale_subdomain(self):
+        """'https://*.tailnet.ts.net' glob matches a real Tailscale hostname."""
+        assert (
+            _origin_allowed(
+                "https://laptop.tailnet.ts.net",
+                ["https://*.tailnet.ts.net"],
+            )
+            is True
+        )
+
+    def test_fnmatch_glob_rejects_different_domain(self):
+        """'https://*.tailnet.ts.net' glob rejects a host on a different domain."""
+        assert (
+            _origin_allowed(
+                "https://laptop.example.com",
+                ["https://*.tailnet.ts.net"],
+            )
+            is False
+        )
+
+    def test_fnmatch_glob_rejects_different_scheme(self):
+        """'https://*.tailnet.ts.net' glob rejects an http:// origin (scheme mismatch)."""
+        assert (
+            _origin_allowed(
+                "http://laptop.tailnet.ts.net",
+                ["https://*.tailnet.ts.net"],
+            )
+            is False
+        )
+
+    def test_empty_origin_empty_patterns_returns_false(self):
+        """Empty origin with empty pattern list returns False."""
+        assert _origin_allowed("", []) is False
+
+    def test_multiple_patterns_first_match_wins(self):
+        """Any matching pattern in the list is sufficient to allow the origin."""
+        patterns = [
+            "http://localhost:5173",
+            "https://*.tailnet.ts.net",
+            "https://admin.example.com",
+        ]
+        assert _origin_allowed("https://mydevice.tailnet.ts.net", patterns) is True
+
+    def test_no_patterns_returns_false(self):
+        """An origin against an empty patterns list is always rejected."""
+        assert _origin_allowed("http://localhost:5173", []) is False
+
+    def test_fnmatch_glob_matches_second_level_subdomain(self):
+        """Glob with single '*' does not cross dot boundaries by default (fnmatchcase)."""
+        # fnmatch '*' matches any sequence of characters including dots on some
+        # implementations — document what the actual behaviour is.
+        # The pattern "https://*.tailnet.ts.net" uses a single '*', which in
+        # fnmatch matches any sequence of chars; 'a.b.tailnet.ts.net' would
+        # therefore also match.  This test asserts the current behaviour.
+        result = _origin_allowed(
+            "https://a.b.tailnet.ts.net",
+            ["https://*.tailnet.ts.net"],
+        )
+        # fnmatch '*' DOES match dots — assert the documented behaviour.
+        assert result is True
+
+    def test_case_sensitive_matching(self):
+        """Pattern matching is case-sensitive (fnmatchcase, not fnmatch)."""
+        # 'HTTP://localhost:5173' should NOT match 'http://localhost:5173'.
+        assert _origin_allowed("HTTP://localhost:5173", ["http://localhost:5173"]) is False
+
+    def test_port_inclusive_wildcard_matches_tailnet_origin_with_port(self) -> None:
+        """`https://*.tailnet.ts.net:5173` matches the canonical Vite frontend origin
+        on the tailnet — the documented production setup in config.yaml."""
+        assert _origin_allowed(
+            "https://laptop-paps.tailnet.ts.net:5173",
+            ["https://*.tailnet.ts.net:5173"],
+        ) is True
+
+    def test_port_inclusive_wildcard_rejects_different_port(self) -> None:
+        """A different port must not match the wildcard — confirms fnmatch glob is
+        port-anchored rather than treating the port as variable."""
+        assert _origin_allowed(
+            "https://laptop-paps.tailnet.ts.net:8080",
+            ["https://*.tailnet.ts.net:5173"],
+        ) is False
+
+
+# ===========================================================================
+# Host-resolution logic (inlined in start_ws_server)
+# ===========================================================================
+
+
+class TestHostResolution:
+    """Tests for the JARVIS_REMOTE_ACCESS / api.host resolution logic.
+
+    Uses the local re-implementation _resolve_host() which mirrors the exact
+    three-branch conditional from start_ws_server.
+    """
+
+    def test_default_loopback_when_remote_access_unset(self, monkeypatch):
+        """With JARVIS_REMOTE_ACCESS unset and config default, host stays 127.0.0.1."""
+        monkeypatch.delenv("JARVIS_REMOTE_ACCESS", raising=False)
+        assert _resolve_host("127.0.0.1") == "127.0.0.1"
+
+    def test_remote_access_true_flips_to_all_interfaces(self, monkeypatch):
+        """JARVIS_REMOTE_ACCESS=true with default config host yields 0.0.0.0."""
+        monkeypatch.setenv("JARVIS_REMOTE_ACCESS", "true")
+        assert _resolve_host("127.0.0.1") == "0.0.0.0"
+
+    def test_explicit_config_host_wins_over_remote_access(self, monkeypatch):
+        """Explicit non-default config host is kept even when JARVIS_REMOTE_ACCESS=true."""
+        monkeypatch.setenv("JARVIS_REMOTE_ACCESS", "true")
+        assert _resolve_host("192.168.1.10") == "192.168.1.10"
+
+    @pytest.mark.parametrize(
+        "env_value",
+        ["1", "true", "True", "TRUE", "yes", "YES", "Yes"],
+    )
+    def test_truthy_remote_access_values_enable_all_interfaces(self, monkeypatch, env_value):
+        """All truthy JARVIS_REMOTE_ACCESS values ('1', 'true', 'yes', case-insensitive) flip host."""
+        monkeypatch.setenv("JARVIS_REMOTE_ACCESS", env_value)
+        assert _resolve_host("127.0.0.1") == "0.0.0.0"
+
+    @pytest.mark.parametrize(
+        "env_value",
+        ["0", "false", "False", "FALSE", "no", "NO", ""],
+    )
+    def test_falsy_remote_access_values_keep_loopback(self, monkeypatch, env_value):
+        """Falsy JARVIS_REMOTE_ACCESS values leave host at the default 127.0.0.1."""
+        monkeypatch.setenv("JARVIS_REMOTE_ACCESS", env_value)
+        assert _resolve_host("127.0.0.1") == "127.0.0.1"
+
+    def test_explicit_config_host_unaffected_without_remote_access(self, monkeypatch):
+        """Explicit config host is returned as-is when JARVIS_REMOTE_ACCESS is unset."""
+        monkeypatch.delenv("JARVIS_REMOTE_ACCESS", raising=False)
+        assert _resolve_host("10.0.0.5") == "10.0.0.5"
+
+    def test_remote_access_env_whitespace_stripped(self, monkeypatch):
+        """Leading/trailing whitespace in JARVIS_REMOTE_ACCESS is stripped before comparison."""
+        monkeypatch.setenv("JARVIS_REMOTE_ACCESS", "  true  ")
+        assert _resolve_host("127.0.0.1") == "0.0.0.0"

--- a/tests/utils/test_device_tailscale.py
+++ b/tests/utils/test_device_tailscale.py
@@ -1,0 +1,283 @@
+"""Unit tests for Tailscale-related helpers in utils.device.
+
+Covers:
+- resolve_tailscale_hostname(): env-var fast path, subprocess happy path,
+  all exception paths, bad output paths, and result caching.
+- resolve_advertise_host(): regression for existing env/config priority,
+  Tailscale auto-detect integration, bind_host fallback.
+
+All subprocess calls and env vars are mocked — no real Tailscale binary is
+required or invoked.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+import utils.device as device_module
+from utils.device import resolve_advertise_host, resolve_tailscale_hostname
+
+
+# ---------------------------------------------------------------------------
+# Fixture: reset module-level cache before every test so calls are isolated
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_tailscale_cache():
+    """Reset the module-level Tailscale hostname cache to its initial sentinel.
+
+    resolve_tailscale_hostname caches its result in two module globals after
+    the first call.  Without this fixture each test would see the cached result
+    from the previous test and subprocess would never be called again.
+    """
+    device_module._tailscale_hostname_cache = None
+    device_module._tailscale_hostname_resolved = False
+    yield
+    # Reset again after the test to avoid leaking state to the next file.
+    device_module._tailscale_hostname_cache = None
+    device_module._tailscale_hostname_resolved = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tailscale_stdout(dns_name: str) -> str:
+    """Return a minimal tailscale status JSON blob with the given DNSName."""
+    return json.dumps({"Self": {"DNSName": dns_name}})
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> CompletedProcess:
+    """Build a mock CompletedProcess for subprocess.run."""
+    return CompletedProcess(
+        args=["tailscale", "status", "--json"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# ===========================================================================
+# resolve_tailscale_hostname — env-var fast path
+# ===========================================================================
+
+
+def test_resolve_tailscale_hostname_env_var_wins(monkeypatch):
+    """When TAILSCALE_HOSTNAME is set, it is returned verbatim without calling subprocess."""
+    monkeypatch.setenv("TAILSCALE_HOSTNAME", "my-laptop.tailnet.ts.net")
+
+    with patch("subprocess.run") as mock_run:
+        result = resolve_tailscale_hostname()
+
+    assert result == "my-laptop.tailnet.ts.net"
+    mock_run.assert_not_called()
+
+
+def test_resolve_tailscale_hostname_env_var_whitespace_stripped(monkeypatch):
+    """TAILSCALE_HOSTNAME is stripped of surrounding whitespace."""
+    monkeypatch.setenv("TAILSCALE_HOSTNAME", "  device.ts.net  ")
+
+    result = resolve_tailscale_hostname()
+
+    assert result == "device.ts.net"
+
+
+# ===========================================================================
+# resolve_tailscale_hostname — subprocess happy path
+# ===========================================================================
+
+
+def test_resolve_tailscale_hostname_subprocess_happy_path(monkeypatch):
+    """Returns DNS name from tailscale status --json with trailing dot stripped."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+    stdout = _make_tailscale_stdout("laptop-paps.tailnet.ts.net.")
+
+    with patch("subprocess.run", return_value=_completed(stdout=stdout)) as mock_run:
+        result = resolve_tailscale_hostname()
+
+    assert result == "laptop-paps.tailnet.ts.net"
+    mock_run.assert_called_once()
+
+
+def test_resolve_tailscale_hostname_trailing_dot_stripped(monkeypatch):
+    """The single trailing dot appended by Tailscale FQDN format is removed."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+    stdout = _make_tailscale_stdout("rpi-five.tailnet.ts.net.")
+
+    with patch("subprocess.run", return_value=_completed(stdout=stdout)):
+        result = resolve_tailscale_hostname()
+
+    assert not result.endswith(".")
+    assert result == "rpi-five.tailnet.ts.net"
+
+
+# ===========================================================================
+# resolve_tailscale_hostname — error / bad-output paths
+# ===========================================================================
+
+
+def test_resolve_tailscale_hostname_file_not_found_returns_none(monkeypatch):
+    """Returns None when subprocess.run raises FileNotFoundError (CLI not installed)."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+
+    with patch("subprocess.run", side_effect=FileNotFoundError("tailscale not found")):
+        result = resolve_tailscale_hostname()
+
+    assert result is None
+
+
+def test_resolve_tailscale_hostname_timeout_returns_none(monkeypatch):
+    """Returns None when subprocess.run raises TimeoutExpired (daemon unresponsive)."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["tailscale"], timeout=2.0),
+    ):
+        result = resolve_tailscale_hostname()
+
+    assert result is None
+
+
+def test_resolve_tailscale_hostname_nonzero_returncode_returns_none(monkeypatch):
+    """Returns None when tailscale exits non-zero (daemon not running)."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+
+    with patch(
+        "subprocess.run",
+        return_value=_completed(returncode=1, stdout="", stderr="daemon not running"),
+    ):
+        result = resolve_tailscale_hostname()
+
+    assert result is None
+
+
+def test_resolve_tailscale_hostname_invalid_json_returns_none(monkeypatch):
+    """Returns None when subprocess stdout is not valid JSON."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+
+    with patch("subprocess.run", return_value=_completed(stdout="not-json!!!")):
+        result = resolve_tailscale_hostname()
+
+    assert result is None
+
+
+def test_resolve_tailscale_hostname_missing_dns_name_returns_none(monkeypatch):
+    """Returns None when JSON parses but Self.DNSName is absent."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+    stdout = json.dumps({"Self": {}})
+
+    with patch("subprocess.run", return_value=_completed(stdout=stdout)):
+        result = resolve_tailscale_hostname()
+
+    assert result is None
+
+
+def test_resolve_tailscale_hostname_empty_dns_name_returns_none(monkeypatch):
+    """Returns None when Self.DNSName is present but empty string."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+    stdout = _make_tailscale_stdout("")
+
+    with patch("subprocess.run", return_value=_completed(stdout=stdout)):
+        result = resolve_tailscale_hostname()
+
+    assert result is None
+
+
+# ===========================================================================
+# resolve_tailscale_hostname — caching
+# ===========================================================================
+
+
+def test_resolve_tailscale_hostname_cached_after_first_call(monkeypatch):
+    """subprocess.run is called exactly once; second call returns the cached value."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+    stdout = _make_tailscale_stdout("cached-host.ts.net.")
+
+    with patch("subprocess.run", return_value=_completed(stdout=stdout)) as mock_run:
+        first = resolve_tailscale_hostname()
+        second = resolve_tailscale_hostname()
+
+    assert first == "cached-host.ts.net"
+    assert second == "cached-host.ts.net"
+    mock_run.assert_called_once()
+
+
+def test_resolve_tailscale_hostname_none_cached_after_failure(monkeypatch):
+    """None result is also cached: subprocess is not re-run on repeated calls."""
+    monkeypatch.delenv("TAILSCALE_HOSTNAME", raising=False)
+
+    with patch("subprocess.run", side_effect=FileNotFoundError()) as mock_run:
+        first = resolve_tailscale_hostname()
+        second = resolve_tailscale_hostname()
+
+    assert first is None
+    assert second is None
+    mock_run.assert_called_once()
+
+
+# ===========================================================================
+# resolve_advertise_host — priority regression + Tailscale integration
+# ===========================================================================
+
+
+def test_resolve_advertise_host_env_var_wins_over_all(monkeypatch):
+    """JARVIS_MCP_ADVERTISE_HOST env var takes priority over config and Tailscale."""
+    monkeypatch.setenv("JARVIS_MCP_ADVERTISE_HOST", "explicit.host.example")
+    mcp_config = {"advertise_host": "config-host", "bind_host": "127.0.0.1"}
+
+    with patch.object(device_module, "resolve_tailscale_hostname", return_value="ts-host"):
+        result = resolve_advertise_host(mcp_config)
+
+    assert result == "explicit.host.example"
+
+
+def test_resolve_advertise_host_config_wins_over_tailscale(monkeypatch):
+    """mcp_config['advertise_host'] wins over Tailscale auto-detect when env var is absent."""
+    monkeypatch.delenv("JARVIS_MCP_ADVERTISE_HOST", raising=False)
+    mcp_config = {"advertise_host": "config-host.example", "bind_host": "127.0.0.1"}
+
+    with patch.object(device_module, "resolve_tailscale_hostname", return_value="ts-host"):
+        result = resolve_advertise_host(mcp_config)
+
+    assert result == "config-host.example"
+
+
+def test_resolve_advertise_host_tailscale_autodetect_used(monkeypatch):
+    """Tailscale auto-detect is used when both env var and config advertise_host are absent."""
+    monkeypatch.delenv("JARVIS_MCP_ADVERTISE_HOST", raising=False)
+    mcp_config = {"bind_host": "127.0.0.1"}
+
+    with patch.object(device_module, "resolve_tailscale_hostname", return_value="ts-auto.ts.net"):
+        result = resolve_advertise_host(mcp_config)
+
+    assert result == "ts-auto.ts.net"
+
+
+def test_resolve_advertise_host_falls_back_to_bind_host(monkeypatch):
+    """Falls back to mcp_config['bind_host'] when env var, config, and Tailscale all return nothing."""
+    monkeypatch.delenv("JARVIS_MCP_ADVERTISE_HOST", raising=False)
+    mcp_config = {"bind_host": "192.168.1.50"}
+
+    with patch.object(device_module, "resolve_tailscale_hostname", return_value=None):
+        result = resolve_advertise_host(mcp_config)
+
+    assert result == "192.168.1.50"
+
+
+def test_resolve_advertise_host_falls_back_to_default_loopback(monkeypatch):
+    """Falls back to '127.0.0.1' when bind_host is also absent and Tailscale returns nothing."""
+    monkeypatch.delenv("JARVIS_MCP_ADVERTISE_HOST", raising=False)
+    mcp_config = {}
+
+    with patch.object(device_module, "resolve_tailscale_hostname", return_value=None):
+        result = resolve_advertise_host(mcp_config)
+
+    assert result == "127.0.0.1"


### PR DESCRIPTION
## Summary
- Backend can now bind on the tailnet (`JARVIS_REMOTE_ACCESS=true` → `0.0.0.0`) so multi-device clients reach JARVIS over Tailscale without exposing ports publicly. Tailscale ACL is the auth boundary; explicit non-default `api.host` values in config always win.
- `mcp.advertise_host` auto-detects from `TAILSCALE_HOSTNAME` or `tailscale status --json`. Subprocess is primed once in sync startup so the async MCP path is a non-blocking cache hit.
- CORS supports `fnmatch` globs (e.g. `https://*.tailnet.ts.net:5173`). Patterns must include the port — fnmatch globs do not span `:` boundaries; documented in both `config/config.yaml` and the setup guide.
- `docs/ops/tailscale-setup.md` covers install, `tailscale up`, CORS, MCP advertise_host, multi-device ACL, and RPi migration.
- `.env.example` adds the three new env vars and a cross-reference for `openclaw.gateway_url`.
- `docker-compose.yml` + `docker-compose.rpi.yml` pass through `JARVIS_REMOTE_ACCESS`, `TAILSCALE_HOSTNAME`, `JARVIS_MCP_ADVERTISE_HOST`.

## Policy change (also in this PR)
- `CLAUDE.md` "Voice Narration via JARVIS Narration Queue" elevated to a hard rule: **every user-facing status update from the orchestrator is paired with a `jarvis_notify`** so JARVIS speaks it. Skip only batch / intermediate steps and pure conversation. The 10 s `completion` batching by `source` already deduplicates near-simultaneous fires — orchestrator does not hand-batch.

## Tests
- 50 new unit tests in `tests/utils/test_device_tailscale.py` and `tests/api/test_ws_server_cors_and_host.py` covering: `resolve_tailscale_hostname` (env path, subprocess happy path, trailing-dot strip, FileNotFoundError, TimeoutExpired, non-zero returncode, invalid JSON, empty DNSName, caching), `resolve_advertise_host` four-step priority chain, `_origin_allowed` (literal / `*` / fnmatch glob / scheme mismatch / port-inclusive wildcard regression), and the `JARVIS_REMOTE_ACCESS` truthy/falsy parsing matrix.
- All external calls mocked. No live network.
- Full suite: **1208/1208 passing**.

## Test plan
- [ ] On a Tailscale-enabled host: set `JARVIS_REMOTE_ACCESS=true`, restart backend, confirm log line `WebSocket server started on 0.0.0.0:8765` and `MCP advertise host from Tailscale auto-detect: <hostname>.tailnet.ts.net`.
- [ ] From a peer device: `curl http://<host>.tailnet.ts.net:8766/health` returns 200.
- [ ] Frontend at `https://<host>.tailnet.ts.net:5173` connects WS + REST without CORS errors when `cors_origins` includes `https://*.tailnet.ts.net:5173`.
- [ ] Default install (env vars unset) is unchanged: backend still binds 127.0.0.1, advertise_host falls back to bind_host.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)