### PR TITLE
chore(config): wire local tailnet — vite host + cors + openclaw loopback

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -88,7 +88,10 @@ api:
   # tailnet subdomain on port 5173, e.g. "https://laptop-paps.tailnet.ts.net:5173".
   # Patterns must include the port for non-default ports — fnmatch's `*` does
   # not cross `:` boundaries by convention.
-  cors_origins: ["http://localhost:5173"]
+  cors_origins:
+    - "http://localhost:5173"
+    - "http://*.tail77bd3b.ts.net:5173"
+    - "https://*.tail77bd3b.ts.net:5173"
 
 logging:
   level: "DEBUG"
@@ -137,7 +140,7 @@ openclaw:
   # For remote OpenClaw via Tailscale, use the gateway host's tailnet URL,
   # e.g. "http://100.84.x.y:18789". For local OpenClaw, use "http://127.0.0.1:18789".
   # Do NOT change this to a Tailscale URL here — update your own tailnet IP.
-  gateway_url: "http://192.168.1.121:18789"
+  gateway_url: "http://127.0.0.1:18789"
   gateway_port: 18789
   managed_daemon: false  # true = JARVIS starts/stops daemon; false = assume systemd
   health_check_interval_seconds: 30

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -58,6 +58,8 @@ export default defineConfig(({ mode }) => {
             ],
         },
         server: {
+            host: '0.0.0.0',
+            allowedHosts: ['.tail77bd3b.ts.net'],
             port: 5173,
             proxy: {
                 '/jarvis-ws': {


### PR DESCRIPTION
## Summary

Three small config changes to make this Linux laptop work as the tailnet-side JARVIS server (per #98 follow-up):

- **`frontend/vite.config.ts`**: `server.host: '0.0.0.0'` + `server.allowedHosts: ['.tail77bd3b.ts.net']` — Vite 5+ blocks non-localhost host headers by default; the leading-dot wildcard is the sanctioned form for any subdomain on this tailnet.
- **`config/config.yaml api.cors_origins`**: single-line → multi-line list with `http://*.tail77bd3b.ts.net:5173` and the `https://` variant (port mandatory in fnmatch wildcards per the inline comment).
- **`config/config.yaml openclaw.gateway_url`**: `192.168.1.121:18789` → `127.0.0.1:18789`. JARVIS and OpenClaw co-locate on this host now; loopback is faster and bypasses LAN/firewall. Remote frontends reach OpenClaw via JARVIS-Backend per architecture.

No code changes, only config. No tests because nothing under test changed; pre-existing test suite is unaffected.

## Test plan

- [x] Backend boots: `API bind host: '0.0.0.0' (source: env-remote-access)`, `OpenClaw gateway connection verified` (loopback), `MCP advertise host: paps-zenbook.tail77bd3b.ts.net`.
- [x] Frontend boots: Vite shows `Network: http://100.95.209.37:5173/` and `Network: http://192.168.1.121:5173/`.
- [x] User confirmed Windows-laptop-side tailnet access works.
- [x] YAML still parses (`yaml.safe_load` — verified by backend startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)