### PR TITLE
feat(auth): static bearer-token auth for non-loopback access (#112)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,8 @@ GITLAB_TOKEN=
 # When you run JARVIS as a multi-device service over Tailscale:
 # - JARVIS_REMOTE_ACCESS=true flips api.host from 127.0.0.1 to 0.0.0.0 so the
 #   backend listens on the tailnet interface as well as loopback. Tailscale
-#   ACL is your auth boundary — there is no API-level token check yet.
+#   ACL is your primary auth boundary; set JARVIS_API_TOKEN below for an
+#   additional bearer-token layer (defence-in-depth).
 # - TAILSCALE_HOSTNAME or `tailscale status --json` is auto-detected at
 #   startup to populate mcp.advertise_host. Set explicitly only to override.
 # - JARVIS_MCP_ADVERTISE_HOST is still the highest-priority override.
@@ -99,3 +100,21 @@ GITLAB_TOKEN=
 # tailnet address, e.g.:
 #   gateway_url: "http://linux-laptop.tailnet.ts.net:18789"
 # (config.yaml key — not an env var. Listed here for cross-reference.)
+
+# ------------------------------------------------------------------------------
+# API Token Authentication (optional)
+# When set, all non-loopback requests must present `Authorization: Bearer <token>`
+# (HTTP/REST) or `?token=<token>` (WebSocket browser handshake). Loopback (127.0.0.1
+# / ::1) is always exempted, so local development continues to work without setting
+# this. /health is also always public for deploy probes.
+#
+# Generate a 32-byte hex token:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+#
+# When unset/empty, no auth — backend behaves as before (Tailscale ACL is the only
+# boundary). Token enforcement is opt-in.
+# ------------------------------------------------------------------------------
+# JARVIS_API_TOKEN=your_64_hex_chars_here
+
+# Frontend equivalent: set VITE_JARVIS_TOKEN in frontend/.env (gitignored) or
+# write the token into localStorage["jarvis_api_token"] on remote browser clients.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ curl -s -X POST http://127.0.0.1:8766/api/jarvis/notify \
 
 **Backend-host rule:** the notify URL must match the backend that actually drives the user's speakers/HUD. When the user works against a **remote backend** (e.g. the developer's Vite dev server is proxying to JARVIS on the Linux laptop over Tailscale, see `docs/ops/tailscale-setup.md`), the orchestrator MUST swap the curl URL to that backend's tailnet hostname (e.g. `http://paps-zenbook.tail77bd3b.ts.net:8766/api/jarvis/notify`) — otherwise the notification is queued on the wrong (or dead) local backend and the user never hears it. Default is loopback; check the active backend host before firing if uncertain.
 
+If `JARVIS_API_TOKEN` is set on the active backend, the orchestrator MUST add `-H "Authorization: Bearer $JARVIS_API_TOKEN"` to the curl. Loopback notify still works without the token (loopback exemption), but Tailscale-routed notifies need it.
+
 **Severity guide:**
 - `completion` — work finished, voice + HUD, **batched 10 s by `source`** (multiple completions in 10 s with same source merge into one utterance).
 - `urgent` — broken state needing immediate attention; voice + HUD with "Verzeihung, Sir — kurz: …" pre-roll.

--- a/docs/ops/tailscale-setup.md
+++ b/docs/ops/tailscale-setup.md
@@ -1,8 +1,9 @@
 # Tailscale Remote Access Setup
 
 Connect multiple devices to a JARVIS backend running on one host without
-exposing any port to the public internet. Tailscale ACL is the authentication
-boundary — there is no API-level token check in JARVIS today.
+exposing any port to the public internet. Tailscale ACL is the primary
+authentication boundary; an optional bearer-token layer (`JARVIS_API_TOKEN`)
+provides defence-in-depth — see "Token authentication" below.
 
 ---
 
@@ -156,6 +157,70 @@ browser sees the request as coming from `http://localhost:5173`, which is
 already in the default `cors_origins`.
 
 Restart `npm run dev` after editing `.env.local` — Vite reads env at startup.
+
+---
+
+### Token authentication (optional, opt-in)
+
+Tailscale ACL is the primary network boundary. `JARVIS_API_TOKEN` adds a second
+factor: any device on the tailnet must also present a static bearer token with
+every request. Enable it when you want defence-in-depth beyond what the ACL
+alone provides.
+
+**When to enable** — recommended whenever remote tailnet devices can reach the
+backend and you want an extra guard against misconfigured ACL rules or a
+compromised device on the tailnet.
+
+**Generate a token:**
+```bash
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+**Backend:** add the output to `.env` on the JARVIS host and restart the backend:
+```bash
+JARVIS_API_TOKEN=<your_64_hex_chars>
+```
+The startup log will emit:
+```
+API token auth enabled — non-loopback requests require Bearer token
+```
+
+**Frontend (Vite dev):** set the same value in `frontend/.env` (gitignored) and
+restart `npm run dev`:
+```
+VITE_JARVIS_TOKEN=<your_64_hex_chars>
+```
+
+**Frontend (deployed build / remote browser):** open DevTools console on the
+device and run once:
+```javascript
+localStorage.setItem("jarvis_api_token", "<your_64_hex_chars>");
+location.reload();
+```
+
+**OpenClaw:** non-loopback OpenClaw access to the MCP server (`:8767`) is
+currently NOT supported with token auth. The MCP server binds to loopback
+(`127.0.0.1`) by design. If OpenClaw runs on a different host and needs to reach
+JARVIS MCP, use an SSH tunnel instead of exposing the port:
+```bash
+ssh -L 8767:127.0.0.1:8767 user@jarvis-host
+```
+Auto-injection of the bearer header into the OpenClaw MCP registry entry is a
+planned follow-up.
+
+**Rotation:** generate a new token, update `JARVIS_API_TOKEN` in `.env` on the
+backend, update `VITE_JARVIS_TOKEN` in `frontend/.env` (or run the
+`localStorage.setItem(...)` snippet in DevTools on every remote browser), then
+restart the backend. All active sessions will receive 401s until they are
+reloaded with the new token.
+
+**Loopback exemption:** local development with `JARVIS_API_TOKEN` unset works
+exactly as today. Even with the token set, requests from `127.0.0.1` or `::1`
+are unconditionally exempted — local dev never needs the token.
+
+**`/health` is always public:** the `/health` endpoint returns
+`{"status": "ok"}` without requiring a token, even when token auth is enabled.
+This endpoint is used by deploy probes and the Vite dev-server upstream check.
 
 ---
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -30,3 +30,11 @@
 # VITE_BACKEND_HOST=<machine>.tail-xxxxx.ts.net
 # VITE_BACKEND_HTTP_PORT=8766
 # VITE_BACKEND_WS_PORT=8765
+
+# API token for non-loopback backend access. Required when the backend has
+# JARVIS_API_TOKEN set in its .env. Generate with:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+# Loopback (127.0.0.1, ::1) is always exempted, so leave this unset for
+# local-only dev. For deployed/remote browsers, set localStorage["jarvis_api_token"]
+# instead — see docs/ops/tailscale-setup.md.
+# VITE_JARVIS_TOKEN=

--- a/frontend/src/core/api/__tests__/baseApi.token.test.ts
+++ b/frontend/src/core/api/__tests__/baseApi.token.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the prepareHeaders callback in baseApi.ts.
+ *
+ * Strategy: mock @core/api/tokenStore before importing baseApi, then test
+ * the prepareHeaders logic directly by calling it with a real Headers object.
+ *
+ * We do NOT call fetchBaseQuery end-to-end (which would require a real fetch
+ * and absolute URL resolution).  Instead we isolate the prepareHeaders arrow
+ * function by reproducing it in-test with the same mock getApiToken that
+ * baseApi.ts uses.  This is both simpler and more direct.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock tokenStore BEFORE any imports that reference it.
+// ---------------------------------------------------------------------------
+
+vi.mock('@core/api/tokenStore', () => ({
+    getApiToken: vi.fn<[], string>(() => ''),
+}));
+
+// Now import the mock so tests can control its return value.
+import { getApiToken } from '@core/api/tokenStore';
+
+const mockGetApiToken = getApiToken as ReturnType<typeof vi.fn<[], string>>;
+const VALID_TOKEN = 'b'.repeat(64);
+
+// ---------------------------------------------------------------------------
+// The function under test — mirrors baseApi.ts prepareHeaders exactly.
+// Defined here so we can invoke it in isolation without involving RTK Query
+// infrastructure.
+// ---------------------------------------------------------------------------
+
+function prepareHeaders(headers: Headers): Headers {
+    const token = getApiToken();
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+    return headers;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+    mockGetApiToken.mockReturnValue('');
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('baseApi prepareHeaders — Authorization header injection', () => {
+    it('sets Authorization: Bearer <token> when getApiToken returns a non-empty string', () => {
+        /**
+         * AC 14: prepareHeaders injects Authorization: Bearer <token> when token is set.
+         */
+        mockGetApiToken.mockReturnValue(VALID_TOKEN);
+        const headers = prepareHeaders(new Headers());
+        expect(headers.get('Authorization')).toBe(`Bearer ${VALID_TOKEN}`);
+    });
+
+    it('does not add Authorization header when getApiToken returns empty string', () => {
+        /**
+         * AC 14: no Authorization header injected when token is "".
+         */
+        mockGetApiToken.mockReturnValue('');
+        const headers = prepareHeaders(new Headers());
+        expect(headers.get('Authorization')).toBeNull();
+    });
+
+    it('preserves pre-existing headers when token is set (additive, not replacing)', () => {
+        /**
+         * prepareHeaders must be additive — it must not clear pre-existing headers.
+         */
+        mockGetApiToken.mockReturnValue(VALID_TOKEN);
+        const existing = new Headers({ 'Content-Type': 'application/json' });
+        const headers = prepareHeaders(existing);
+        expect(headers.get('Content-Type')).toBe('application/json');
+        expect(headers.get('Authorization')).toBe(`Bearer ${VALID_TOKEN}`);
+    });
+});

--- a/frontend/src/core/api/__tests__/tokenStore.test.ts
+++ b/frontend/src/core/api/__tests__/tokenStore.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for getApiToken() in tokenStore.ts.
+ *
+ * Strategy:
+ *  - vi.stubEnv controls import.meta.env.VITE_JARVIS_TOKEN.
+ *  - jsdom's in-memory localStorage is reset between tests via localStorage.clear().
+ *  - The SecurityError path mocks localStorage.getItem to throw.
+ *
+ * vi.resetModules() + dynamic import ensures each test gets a fresh module
+ * evaluation (important because the function reads live globals each call, but
+ * re-importing ensures mock state is clean and avoids cross-test pollution).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const VALID_TOKEN = 'a'.repeat(64);
+
+beforeEach(() => {
+    localStorage.clear();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+});
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: import a fresh copy of tokenStore after env stubs are set.
+// ---------------------------------------------------------------------------
+
+async function freshGetApiToken(): Promise<() => string> {
+    const mod = await import('../tokenStore');
+    return mod.getApiToken;
+}
+
+describe('getApiToken — VITE_JARVIS_TOKEN env var', () => {
+    it('returns the env var value when VITE_JARVIS_TOKEN is set to a non-empty string', async () => {
+        /**
+         * Primary resolution path: env var is present and truthy.
+         */
+        vi.stubEnv('VITE_JARVIS_TOKEN', VALID_TOKEN);
+        const getApiToken = await freshGetApiToken();
+        expect(getApiToken()).toBe(VALID_TOKEN);
+    });
+
+    it('falls through to localStorage when VITE_JARVIS_TOKEN is an empty string', async () => {
+        /**
+         * Empty-string env var must not be treated as set — should fall through.
+         */
+        vi.stubEnv('VITE_JARVIS_TOKEN', '');
+        localStorage.setItem('jarvis_api_token', 'from-localstorage');
+        const getApiToken = await freshGetApiToken();
+        expect(getApiToken()).toBe('from-localstorage');
+    });
+});
+
+describe('getApiToken — localStorage fallback', () => {
+    it('returns localStorage value when env var is absent and localStorage is set', async () => {
+        /**
+         * AC 13: falls through to localStorage["jarvis_api_token"] when env var absent.
+         */
+        // env var deliberately not stubbed (remains undefined).
+        localStorage.setItem('jarvis_api_token', VALID_TOKEN);
+        const getApiToken = await freshGetApiToken();
+        expect(getApiToken()).toBe(VALID_TOKEN);
+    });
+
+    it('returns empty string when neither env var nor localStorage is set', async () => {
+        /**
+         * Final fallback: both sources empty → "".
+         */
+        const getApiToken = await freshGetApiToken();
+        expect(getApiToken()).toBe('');
+    });
+
+    it('returns empty string and logs console.warn when localStorage throws SecurityError', async () => {
+        /**
+         * Edge case: private-browsing / sandboxed iframe where localStorage access is
+         * blocked. getApiToken() must not throw — it returns "" and emits a warn.
+         */
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            const err = new DOMException('SecurityError', 'SecurityError');
+            throw err;
+        });
+
+        const getApiToken = await freshGetApiToken();
+        const result = getApiToken();
+
+        expect(result).toBe('');
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('localStorage');
+
+        getItemSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+});

--- a/frontend/src/core/api/baseApi.ts
+++ b/frontend/src/core/api/baseApi.ts
@@ -1,8 +1,20 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { getApiToken } from './tokenStore';
+
+const baseQuery = fetchBaseQuery({
+    baseUrl: '/',
+    prepareHeaders: (headers) => {
+        const token = getApiToken();
+        if (token) {
+            headers.set('Authorization', `Bearer ${token}`);
+        }
+        return headers;
+    },
+});
 
 export const baseApi = createApi({
     reducerPath: 'api',
-    baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+    baseQuery,
     tagTypes: ['repos', 'queue'],
     endpoints: () => ({}),
 });

--- a/frontend/src/core/api/tokenStore.ts
+++ b/frontend/src/core/api/tokenStore.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolves the JARVIS API bearer token from one of three sources, in priority
+ * order:
+ *
+ *  1. `import.meta.env.VITE_JARVIS_TOKEN` — Vite build-time env var (local dev).
+ *  2. `localStorage["jarvis_api_token"]`   — operator-written for deployed builds.
+ *  3. `""`                                  — fallback; token auth disabled client-side.
+ *
+ * This is a plain function (not a hook) so it can be called from both RTK
+ * Query's `prepareHeaders` and `wsClient.connect`.
+ */
+
+export function getApiToken(): string {
+    const envToken = import.meta.env.VITE_JARVIS_TOKEN;
+    if (typeof envToken === 'string' && envToken.length > 0) {
+        return envToken;
+    }
+
+    try {
+        const stored = localStorage.getItem('jarvis_api_token');
+        if (stored !== null && stored.length > 0) {
+            return stored;
+        }
+    } catch (err) {
+        console.warn('[tokenStore] localStorage unavailable — token auth disabled client-side.', err);
+    }
+
+    return '';
+}

--- a/frontend/src/core/websocket/__tests__/wsClient.token.test.ts
+++ b/frontend/src/core/websocket/__tests__/wsClient.token.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for the API-token injection in wsClient.ts.
+ *
+ * Strategy:
+ *  - Mock @core/api/tokenStore so getApiToken() is controllable.
+ *  - Replace globalThis.WebSocket with a spy that records constructor call URLs.
+ *  - Use vi.resetModules() + dynamic import to get a fresh wsClient singleton
+ *    per test (required because wsClient is a module-level singleton).
+ *
+ * AC 15: wsClient.connect(url) appends ?token=<value> when token is non-empty;
+ *         passes URL unchanged when token is "".
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock tokenStore — set up before any dynamic imports.
+// ---------------------------------------------------------------------------
+
+vi.mock('@core/api/tokenStore', () => ({
+    getApiToken: vi.fn(() => ''),
+}));
+
+import { getApiToken } from '@core/api/tokenStore';
+
+const VALID_TOKEN = 'c'.repeat(64);
+const BASE_URL = 'ws://localhost:8765/ws';
+const BASE_URL_WITH_QUERY = 'ws://localhost:8765/ws?foo=bar';
+
+// ---------------------------------------------------------------------------
+// WebSocket constructor spy — tracks every URL passed to `new WebSocket(url)`.
+// ---------------------------------------------------------------------------
+
+let constructedUrls: string[] = [];
+
+class SpyWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 3;
+
+    readyState = SpyWebSocket.CONNECTING;
+    onopen: ((ev: Event) => void) | null = null;
+    onclose: ((ev: CloseEvent) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+
+    constructor(url: string) {
+        constructedUrls.push(url);
+    }
+
+    close(): void {
+        this.readyState = SpyWebSocket.CLOSED;
+        this.onclose?.(new CloseEvent('close'));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    send(_data: string | ArrayBuffer): void {}
+}
+
+beforeEach(() => {
+    constructedUrls = [];
+    vi.stubGlobal('WebSocket', SpyWebSocket);
+    vi.useFakeTimers();
+    vi.resetModules();
+    // Reset getApiToken to return empty string by default.
+    (getApiToken as ReturnType<typeof vi.fn>).mockReturnValue('');
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: import a fresh wsClient after mocks are configured.
+// ---------------------------------------------------------------------------
+
+async function freshWsClient() {
+    const mod = await import('../wsClient');
+    return mod.wsClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('wsClient token injection — no token', () => {
+    it('passes the bare URL unchanged to new WebSocket() when getApiToken returns ""', async () => {
+        /**
+         * AC 15: URL is not modified when token is empty.
+         */
+        (getApiToken as ReturnType<typeof vi.fn>).mockReturnValue('');
+        const client = await freshWsClient();
+        client.connect(BASE_URL);
+        expect(constructedUrls).toHaveLength(1);
+        expect(constructedUrls[0]).toBe(BASE_URL);
+    });
+});
+
+describe('wsClient token injection — with token', () => {
+    it('appends ?token=<value> to the URL when getApiToken returns a non-empty string', async () => {
+        /**
+         * AC 15: ?token=<value> appended when token is configured.
+         */
+        (getApiToken as ReturnType<typeof vi.fn>).mockReturnValue(VALID_TOKEN);
+        const client = await freshWsClient();
+        client.connect(BASE_URL);
+        expect(constructedUrls).toHaveLength(1);
+        expect(constructedUrls[0]).toContain(`token=${VALID_TOKEN}`);
+    });
+
+    it('appends &token=<value> when the base URL already has a query string', async () => {
+        /**
+         * Uses URL.searchParams.set — correctly handles pre-existing query params
+         * by using & separator instead of ?.
+         */
+        (getApiToken as ReturnType<typeof vi.fn>).mockReturnValue(VALID_TOKEN);
+        const client = await freshWsClient();
+        client.connect(BASE_URL_WITH_QUERY);
+        expect(constructedUrls).toHaveLength(1);
+        const constructed = constructedUrls[0];
+        // Both the original param and the token must be present.
+        expect(constructed).toContain('foo=bar');
+        expect(constructed).toContain(`token=${VALID_TOKEN}`);
+        // The URL must NOT have a duplicate '?' (only one query separator).
+        const questionMarkCount = (constructed.match(/\?/g) || []).length;
+        expect(questionMarkCount).toBe(1);
+    });
+});
+
+describe('wsClient token injection — idempotency (bare URL anchor)', () => {
+    it('does not create a second WebSocket when connect() is called twice with the same bare URL', async () => {
+        /**
+         * The internal this.url stores the bare URL (without token) so that a second
+         * call to connect(url) with the same bare URL is recognized as a no-op.
+         * The WebSocket constructor must be invoked exactly once.
+         */
+        (getApiToken as ReturnType<typeof vi.fn>).mockReturnValue(VALID_TOKEN);
+        const client = await freshWsClient();
+        client.connect(BASE_URL);
+        client.connect(BASE_URL); // second call — must be idempotent
+        expect(constructedUrls).toHaveLength(1);
+    });
+});

--- a/frontend/src/core/websocket/wsClient.ts
+++ b/frontend/src/core/websocket/wsClient.ts
@@ -10,6 +10,8 @@
  * and use `wsClient` instead.
  */
 
+import { getApiToken } from '@core/api/tokenStore';
+
 export type WsReadyState = 'connecting' | 'open' | 'closed';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -147,12 +149,28 @@ class WsClientImpl implements WsClient {
     // Internal helpers
     // ---------------------------------------------------------------------------
 
+    /**
+     * Builds the full WebSocket URL with the API token appended as a query
+     * parameter when a token is configured. Uses the URL API to handle
+     * pre-existing query strings correctly and avoid double-encoding.
+     *
+     * `this.url` (the bare base URL) is never mutated — idempotency checks in
+     * `connect()` always compare against the raw input URL.
+     */
+    private buildWsUrl(baseUrl: string): string {
+        const token = getApiToken();
+        if (!token) return baseUrl;
+        const url = new URL(baseUrl, window.location.origin);
+        url.searchParams.set('token', token);
+        return url.toString();
+    }
+
     private openSocket(): void {
         if (!this.url) return;
         if (this.ws && this.ws.readyState <= WebSocket.OPEN) return;
 
         this.setReadyState('connecting');
-        const ws = new WebSocket(this.url);
+        const ws = new WebSocket(this.buildWsUrl(this.url));
         this.ws = ws;
 
         ws.onopen = () => {

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -9,6 +9,7 @@ and Fish Audio TTS — then streams the MP3 response back to the frontend.
 import asyncio
 import base64
 import fnmatch
+import hmac
 import json
 import os
 import socket
@@ -3989,6 +3990,16 @@ async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
     Returns:
         WebSocket response
     """
+    # Token-auth gate — must run BEFORE ws.prepare so the HTTP upgrade can be
+    # denied with a plain 401 instead of an already-established WS connection.
+    enabled, expected = _is_token_auth_enabled()
+    if enabled and not _is_loopback(request):
+        extracted = _extract_request_token(request)
+        if not extracted or not hmac.compare_digest(extracted, expected):
+            raise web.HTTPUnauthorized(
+                headers={"WWW-Authenticate": 'Bearer realm="jarvis"'}
+            )
+
     ws = web.WebSocketResponse()
     await ws.prepare(request)
 
@@ -4462,7 +4473,103 @@ def _is_loopback(request: web.Request) -> bool:
     if peername is None:
         return False
     host = peername[0] if isinstance(peername, (list, tuple)) else str(peername)
-    return host in {"127.0.0.1", "::1", "localhost"}
+    return host in {"127.0.0.1", "::1"}
+
+
+# ---------------------------------------------------------------------------
+# API token authentication helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_token_auth_enabled() -> tuple[bool, str]:
+    """Return (enabled, token) based on the JARVIS_API_TOKEN environment variable.
+
+    Reads ``os.environ`` directly (not the config layer) because the token must
+    be available before the full config stack is wired up and because it is an
+    operational secret, not a tuneable.  Returns ``(False, "")`` when the
+    variable is absent or whitespace-only.
+    """
+    raw_env = os.environ.get("JARVIS_API_TOKEN")
+    if raw_env is None:
+        return (False, "")
+    raw = raw_env.strip()
+    if not raw:
+        logger.warning(
+            "JARVIS_API_TOKEN is set but empty after strip — token auth disabled"
+        )
+        return (False, "")
+    if len(raw) < 32:
+        logger.warning(
+            "JARVIS_API_TOKEN is shorter than 32 bytes — consider regenerating for better entropy"
+        )
+    return (True, raw)
+
+
+def _extract_request_token(request: web.Request) -> str:
+    """Extract the bearer token from the request.
+
+    Checks the ``Authorization: Bearer <token>`` header first.  Falls through
+    to the ``?token=`` query parameter **only** when no ``Authorization`` header
+    is present at all.  Returns ``""`` when neither source provides a token.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header:
+        # Header is present (even if malformed) — do NOT fall through to ?token=
+        if auth_header.startswith("Bearer "):
+            header_token = auth_header[len("Bearer "):]
+            query_token = request.rel_url.query.get("token", "")
+            if query_token and query_token != header_token:
+                logger.debug(
+                    "Both Authorization header and ?token= query param present "
+                    "with differing values; header takes precedence (likely misconfiguration)"
+                )
+            return header_token
+        logger.debug("Authorization header present but not Bearer-prefixed — ignoring")
+        return ""
+    # No Authorization header — try query param (browser WS path)
+    return request.rel_url.query.get("token", "")
+
+
+@web.middleware
+async def auth_middleware(request: web.Request, handler: Any) -> web.Response:
+    """Reject non-loopback requests that lack a valid bearer token.
+
+    No-op when ``JARVIS_API_TOKEN`` is unset or empty.  Loopback requests
+    (``127.0.0.1`` / ``::1``) and ``OPTIONS`` preflights are always passed
+    through.  ``/health`` is unconditionally public.
+    """
+    enabled, expected = _is_token_auth_enabled()
+    if not enabled:
+        return await handler(request)
+    if request.method == "OPTIONS":
+        return await handler(request)
+    if _is_loopback(request):
+        return await handler(request)
+    if request.path == "/health":
+        return await handler(request)
+
+    extracted = _extract_request_token(request)
+    # hmac.compare_digest requires both operands to be the same type (str).
+    if not extracted or not hmac.compare_digest(extracted, expected):
+        return web.json_response(
+            {"error": "unauthorized"},
+            status=401,
+            headers={"WWW-Authenticate": 'Bearer realm="jarvis"'},
+        )
+    return await handler(request)
+
+
+async def config_token_handler(request: web.Request) -> web.Response:
+    """GET /api/config/token — return the active API token for loopback callers.
+
+    Returns ``{"token": ""}`` when ``JARVIS_API_TOKEN`` is unset.  Always
+    returns ``403`` for non-loopback callers regardless of auth state so the
+    token is never exposed over the network.
+    """
+    if not _is_loopback(request):
+        return web.Response(status=403, text="Forbidden: localhost only")
+    _, token = _is_token_auth_enabled()
+    return web.json_response({"token": token})
 
 
 async def voice_metrics_handler(request: web.Request) -> web.Response:
@@ -5028,11 +5135,25 @@ async def start_ws_server(
         if origin and _origin_allowed(origin, cors_origins):
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
-            response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+            response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
 
         return response
 
-    http_app = web.Application(middlewares=[cors_middleware])
+    # Log token-auth status once at startup so operators know whether it's on.
+    _token_enabled, _ = _is_token_auth_enabled()
+    if _token_enabled:
+        logger.info(
+            "API token auth enabled — non-loopback requests require Bearer token"
+        )
+    else:
+        logger.info(
+            "API token auth disabled — all requests accepted "
+            "(set JARVIS_API_TOKEN to enable)"
+        )
+
+    # auth_middleware is registered AFTER cors_middleware so OPTIONS preflights
+    # are answered by cors_middleware before auth_middleware can block them.
+    http_app = web.Application(middlewares=[cors_middleware, auth_middleware])
     http_app.router.add_get("/health", health_handler)
     http_app.router.add_get("/voices", voices_handler)
     http_app.router.add_post("/notify/wife", notify_wife_handler)
@@ -5040,6 +5161,7 @@ async def start_ws_server(
     http_app.router.add_get("/oauth/spotify/callback", spotify_oauth_callback_handler)
     http_app.router.add_get("/api/config/repos", config_repos_get_handler)
     http_app.router.add_post("/api/config/repos", config_repos_post_handler)
+    http_app.router.add_get("/api/config/token", config_token_handler)
     http_app.router.add_get("/api/metrics/voice", voice_metrics_handler)
     http_app.router.add_get("/api/config/location", config_location_handler)
     http_app.router.add_get("/api/mcp/health", mcp_health_handler)

--- a/tests/api/test_token_auth.py
+++ b/tests/api/test_token_auth.py
@@ -1,0 +1,554 @@
+"""Unit tests for API token authentication helpers in ws_server.py.
+
+Covers:
+  - _is_token_auth_enabled: env var presence/absence/whitespace/length warning.
+  - _extract_request_token: Bearer header, query param, malformed header precedence.
+  - auth_middleware: pass-through (no token), OPTIONS, loopback, /health, 401 flows,
+    correct-token acceptance, hmac.compare_digest usage.
+  - websocket_handler token gate: reject before ws.prepare, accept via ?token=, loopback pass.
+  - config_token_handler: loopback vs non-loopback, token present/absent.
+
+All external I/O is mocked. No real sockets, no real HTTP server.
+
+Loguru note: ws_server uses loguru for all logging.  caplog only captures stdlib
+``logging`` records.  For loguru assertions we add a temporary loguru sink via
+``loguru_logger.add()`` and check the captured text.
+"""
+
+from __future__ import annotations
+
+import hmac
+from contextlib import contextmanager
+from typing import Any, Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from loguru import logger as loguru_logger
+
+import api.ws_server as _ws_mod
+from api.ws_server import (
+    _extract_request_token,
+    _is_token_auth_enabled,
+    auth_middleware,
+    config_token_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Loguru capture helper
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _capture_loguru(level: str = "DEBUG") -> Generator[list[str], None, None]:
+    """Context manager that captures loguru log messages into a list of strings."""
+    captured: list[str] = []
+
+    def _sink(message: Any) -> None:
+        captured.append(str(message))
+
+    sink_id = loguru_logger.add(_sink, level=level)
+    try:
+        yield captured
+    finally:
+        loguru_logger.remove(sink_id)
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+_VALID_TOKEN = "a" * 64  # 64-char hex-ish string — clearly >= 32 chars
+
+
+class _FakeTransport:
+    """Minimal asyncio transport stub for peername inspection."""
+
+    def __init__(self, ip: str = "127.0.0.1") -> None:
+        self._ip = ip
+
+    def get_extra_info(self, key: str) -> Any:
+        if key == "peername":
+            return (self._ip, 12345)
+        return None
+
+
+class _FakeRequest:
+    """Minimal stand-in for aiohttp.web.Request.
+
+    Carries exactly the attributes read by _is_loopback, _extract_request_token,
+    auth_middleware, and config_token_handler.
+    """
+
+    def __init__(
+        self,
+        method: str = "GET",
+        path: str = "/api/config/repos",
+        ip: str = "192.168.1.50",
+        headers: dict[str, str] | None = None,
+        query: dict[str, str] | None = None,
+    ) -> None:
+        self.method = method
+        self.path = path
+        self.transport: _FakeTransport | None = _FakeTransport(ip)
+        # Build headers multidict-like object (dict is sufficient — .get is called).
+        self.headers = headers or {}
+        # Build rel_url with a .query dict-like object.
+        _q = query or {}
+        self.rel_url = _FakeRelUrl(_q)
+
+
+class _FakeRelUrl:
+    def __init__(self, query: dict[str, str]) -> None:
+        self.query = query
+
+
+# ---------------------------------------------------------------------------
+# _is_token_auth_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsTokenAuthEnabled:
+    """Tests for _is_token_auth_enabled() — env-var parsing and validation."""
+
+    def test_returns_false_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """(False, '') returned when JARVIS_API_TOKEN is absent from the environment."""
+        monkeypatch.delenv("JARVIS_API_TOKEN", raising=False)
+        enabled, token = _is_token_auth_enabled()
+        assert enabled is False
+        assert token == ""
+
+    def test_returns_false_when_env_var_is_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(False, '') returned when JARVIS_API_TOKEN='' (empty string)."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", "")
+        enabled, token = _is_token_auth_enabled()
+        assert enabled is False
+        assert token == ""
+
+    def test_returns_false_when_env_var_is_whitespace_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(False, '') returned and WARNING logged when JARVIS_API_TOKEN is whitespace-only."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", "   \t\n  ")
+        with _capture_loguru("WARNING") as captured:
+            enabled, token = _is_token_auth_enabled()
+        assert enabled is False
+        assert token == ""
+        assert any("empty after strip" in line for line in captured), (
+            f"Expected WARNING about whitespace-only token in loguru output; got: {captured}"
+        )
+
+    def test_returns_true_and_token_when_env_var_is_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(True, token) returned when JARVIS_API_TOKEN is a 64-char hex string."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        enabled, token = _is_token_auth_enabled()
+        assert enabled is True
+        assert token == _VALID_TOKEN
+
+    def test_returns_true_and_logs_warning_when_token_shorter_than_32_chars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(True, token) returned and a WARNING is logged when token is < 32 chars."""
+        short_token = "abc123"
+        monkeypatch.setenv("JARVIS_API_TOKEN", short_token)
+
+        with _capture_loguru("WARNING") as captured:
+            enabled, token = _is_token_auth_enabled()
+
+        assert enabled is True
+        assert token == short_token
+        assert any("shorter than 32 bytes" in line for line in captured), (
+            f"Expected WARNING about entropy in loguru output; got: {captured}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _extract_request_token
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRequestToken:
+    """Tests for _extract_request_token() — header vs query param extraction."""
+
+    def test_returns_token_from_bearer_header(self) -> None:
+        """Token extracted from a well-formed Authorization: Bearer <token> header."""
+        req = _FakeRequest(headers={"Authorization": f"Bearer {_VALID_TOKEN}"})
+        assert _extract_request_token(req) == _VALID_TOKEN  # type: ignore[arg-type]
+
+    def test_returns_token_from_query_param_when_header_absent(self) -> None:
+        """Falls through to ?token= query param when Authorization header is absent."""
+        req = _FakeRequest(query={"token": _VALID_TOKEN})
+        assert _extract_request_token(req) == _VALID_TOKEN  # type: ignore[arg-type]
+
+    def test_returns_empty_when_neither_present(self) -> None:
+        """Returns '' when neither Authorization header nor ?token= query param exists."""
+        req = _FakeRequest()
+        assert _extract_request_token(req) == ""  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "bad_header",
+        [
+            "Basic abc123",          # wrong scheme — debug log expected
+            "justtoken",             # no scheme at all — debug log expected
+            "bearer lowercase",      # wrong case (case-sensitive) — debug log expected
+        ],
+    )
+    def test_returns_empty_and_logs_debug_when_header_is_not_bearer_prefixed(
+        self, bad_header: str
+    ) -> None:
+        """Non-Bearer-prefixed Authorization header returns '' and does NOT fall through to ?token=.
+
+        A DEBUG log entry is emitted explaining the ignored header.
+        """
+        req = _FakeRequest(
+            headers={"Authorization": bad_header},
+            query={"token": "should-not-be-returned"},
+        )
+        with _capture_loguru("DEBUG") as captured:
+            result = _extract_request_token(req)  # type: ignore[arg-type]
+        assert result == "", f"Expected empty string for malformed header {bad_header!r}"
+        assert any(
+            "Authorization" in line or "Bearer" in line for line in captured
+        ), f"Expected DEBUG log for malformed header {bad_header!r}; got: {captured}"
+
+    def test_returns_empty_when_bearer_header_has_empty_token(self) -> None:
+        """'Authorization: Bearer ' (space only, no token) returns '' without debug log.
+
+        The code treats this as a valid-scheme-but-empty-token case — it returns ''
+        without logging because the Bearer prefix is correct but yields an empty value.
+        The query param is still NOT consulted (header presence wins).
+        """
+        req = _FakeRequest(
+            headers={"Authorization": "Bearer "},
+            query={"token": "should-not-be-returned"},
+        )
+        result = _extract_request_token(req)  # type: ignore[arg-type]
+        assert result == ""
+
+    def test_header_wins_over_query_param_when_both_present(self) -> None:
+        """Authorization header is used when both header and ?token= are present with matching values.
+
+        When both sources carry the same token no DEBUG log is emitted — we only
+        warn on mismatch so that identical values don't produce false-positive noise.
+        """
+        req = _FakeRequest(
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+            query={"token": _VALID_TOKEN},
+        )
+        with _capture_loguru("DEBUG") as captured:
+            result = _extract_request_token(req)  # type: ignore[arg-type]
+        assert result == _VALID_TOKEN
+        assert not any("differing values" in line for line in captured), (
+            "No DEBUG log expected when header and query param carry the same token"
+        )
+
+    def test_debug_log_emitted_when_header_and_query_token_differ(self) -> None:
+        """DEBUG log fires when Authorization header and ?token= carry different values.
+
+        The header value is still returned; the log is informational only.
+        """
+        other_token = "b" * 64
+        req = _FakeRequest(
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+            query={"token": other_token},
+        )
+        with _capture_loguru("DEBUG") as captured:
+            result = _extract_request_token(req)  # type: ignore[arg-type]
+        assert result == _VALID_TOKEN
+        assert any("differing values" in line for line in captured), (
+            f"Expected DEBUG log about differing values; got: {captured}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# auth_middleware
+# ---------------------------------------------------------------------------
+
+
+class TestAuthMiddleware:
+    """Tests for the auth_middleware @web.middleware function."""
+
+    # Shared sentinel handler that records whether it was called.
+
+    @staticmethod
+    def _make_handler(response_value: Any = "ok") -> AsyncMock:
+        handler = AsyncMock(return_value=response_value)
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_pass_through_when_token_auth_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """auth_middleware is a no-op when JARVIS_API_TOKEN is unset."""
+        monkeypatch.delenv("JARVIS_API_TOKEN", raising=False)
+        handler = self._make_handler("downstream")
+        req = _FakeRequest(ip="10.0.0.1")  # non-loopback
+        result = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_called_once_with(req)
+        assert result == "downstream"
+
+    @pytest.mark.asyncio
+    async def test_options_request_passes_through_unconditionally(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OPTIONS preflight requests bypass auth unconditionally (CORS pre-flight)."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler("cors-ok")
+        req = _FakeRequest(method="OPTIONS", ip="10.0.0.1")
+        result = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_called_once()
+        assert result == "cors-ok"
+
+    @pytest.mark.asyncio
+    async def test_loopback_request_passes_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Requests from 127.0.0.1 bypass auth even when JARVIS_API_TOKEN is set."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler("local-ok")
+        req = _FakeRequest(ip="127.0.0.1")
+        result = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_called_once_with(req)
+        assert result == "local-ok"
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_public_from_non_loopback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """/health is always public — non-loopback request without token passes."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler("health-ok")
+        req = _FakeRequest(path="/health", ip="10.0.0.1")
+        result = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_called_once_with(req)
+        assert result == "health-ok"
+
+    @pytest.mark.asyncio
+    async def test_returns_401_from_non_loopback_without_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback request without a token → 401 + WWW-Authenticate + JSON body."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler()
+        req = _FakeRequest(ip="10.0.0.1")
+        resp = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_not_called()
+        assert resp.status == 401
+        assert "Bearer" in resp.headers.get("WWW-Authenticate", "")
+        assert resp.content_type == "application/json"
+        import json as _json
+        body = _json.loads(resp.body)
+        assert body == {"error": "unauthorized"}
+
+    @pytest.mark.asyncio
+    async def test_returns_401_from_non_loopback_with_wrong_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback request with incorrect token → 401."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler()
+        req = _FakeRequest(
+            ip="10.0.0.1",
+            headers={"Authorization": "Bearer wrong-token-value"},
+        )
+        resp = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_not_called()
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_passes_through_with_correct_token_in_authorization_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback request with correct Authorization: Bearer <token> passes."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler("authed-ok")
+        req = _FakeRequest(
+            ip="10.0.0.1",
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+        )
+        result = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_called_once_with(req)
+        assert result == "authed-ok"
+
+    @pytest.mark.asyncio
+    async def test_passes_through_with_correct_token_in_query_param(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback request with correct ?token= passes through."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler("query-ok")
+        req = _FakeRequest(ip="10.0.0.1", query={"token": _VALID_TOKEN})
+        result = await auth_middleware(req, handler)  # type: ignore[arg-type]
+        handler.assert_called_once_with(req)
+        assert result == "query-ok"
+
+    @pytest.mark.asyncio
+    async def test_uses_hmac_compare_digest_for_comparison(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Token comparison delegates to hmac.compare_digest (timing-safe check)."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        handler = self._make_handler("ok")
+        req = _FakeRequest(
+            ip="10.0.0.1",
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+        )
+        with patch("hmac.compare_digest", wraps=hmac.compare_digest) as mock_cd:
+            await auth_middleware(req, handler)  # type: ignore[arg-type]
+        mock_cd.assert_called_once()
+        # Both args passed to compare_digest must be strings (no type mismatch).
+        args = mock_cd.call_args[0]
+        assert all(isinstance(a, str) for a in args), (
+            "hmac.compare_digest must be called with str, not bytes"
+        )
+
+
+# ---------------------------------------------------------------------------
+# websocket_handler token gate
+# ---------------------------------------------------------------------------
+
+
+class _WsPreparePassedSentinel(Exception):
+    """Raised by the WebSocketResponse stub once prepare() is reached.
+
+    Defined at module level so inner classes inside test methods can reference
+    it without NameError.
+    """
+
+
+class TestWebsocketHandlerTokenGate:
+    """Tests for the auth check inside websocket_handler (before ws.prepare)."""
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_without_token_raises_http_unauthorized_before_prepare(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback WS upgrade without a token raises HTTPUnauthorized before prepare."""
+        from aiohttp import web
+
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+
+        req = _FakeRequest(ip="10.0.0.1", path="/ws")
+
+        prepare_called = False
+
+        class _FailOnPrepare:
+            async def prepare(self, _req: Any) -> None:
+                nonlocal prepare_called
+                prepare_called = True
+                raise AssertionError("ws.prepare must not be called on auth failure")
+
+        with patch("api.ws_server.web.WebSocketResponse", return_value=_FailOnPrepare()):
+            with pytest.raises(web.HTTPUnauthorized) as exc_info:
+                await _ws_mod.websocket_handler(req)  # type: ignore[arg-type]
+
+        assert not prepare_called
+        assert "Bearer" in exc_info.value.headers.get("WWW-Authenticate", "")
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_with_valid_token_in_query_passes_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback WS upgrade with correct ?token= passes the auth gate."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+
+        req = _FakeRequest(
+            ip="10.0.0.1",
+            path="/ws",
+            query={"token": _VALID_TOKEN},
+        )
+
+        prepare_called = False
+
+        class _StubWs:
+            async def prepare(self, _req: Any) -> None:
+                nonlocal prepare_called
+                prepare_called = True
+                raise _WsPreparePassedSentinel
+
+        with patch("api.ws_server.web.WebSocketResponse", return_value=_StubWs()):
+            with pytest.raises(_WsPreparePassedSentinel):
+                await _ws_mod.websocket_handler(req)  # type: ignore[arg-type]
+
+        assert prepare_called, "ws.prepare should have been called after auth succeeded"
+
+    @pytest.mark.asyncio
+    async def test_loopback_without_token_passes_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loopback WS upgrade without a token skips the auth check (loopback exemption)."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+
+        req = _FakeRequest(ip="127.0.0.1", path="/ws")
+
+        prepare_called = False
+
+        class _StubWs:
+            async def prepare(self, _req: Any) -> None:
+                nonlocal prepare_called
+                prepare_called = True
+                raise _WsPreparePassedSentinel
+
+        with patch("api.ws_server.web.WebSocketResponse", return_value=_StubWs()):
+            with pytest.raises(_WsPreparePassedSentinel):
+                await _ws_mod.websocket_handler(req)  # type: ignore[arg-type]
+
+        assert prepare_called
+
+
+# ---------------------------------------------------------------------------
+# config_token_handler
+# ---------------------------------------------------------------------------
+
+
+class TestConfigTokenHandler:
+    """Tests for GET /api/config/token handler."""
+
+    @pytest.mark.asyncio
+    async def test_returns_403_for_non_loopback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback request always gets 403 regardless of auth state."""
+        monkeypatch.delenv("JARVIS_API_TOKEN", raising=False)
+        req = _FakeRequest(ip="10.0.0.1", path="/api/config/token")
+        resp = await config_token_handler(req)  # type: ignore[arg-type]
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_returns_403_for_non_loopback_even_when_token_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-loopback request gets 403 even when JARVIS_API_TOKEN is configured."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        req = _FakeRequest(ip="10.0.0.1", path="/api/config/token")
+        resp = await config_token_handler(req)  # type: ignore[arg-type]
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_token_for_loopback_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loopback caller gets {"token": ""} when JARVIS_API_TOKEN is not set."""
+        monkeypatch.delenv("JARVIS_API_TOKEN", raising=False)
+        req = _FakeRequest(ip="127.0.0.1", path="/api/config/token")
+        resp = await config_token_handler(req)  # type: ignore[arg-type]
+        assert resp.status == 200
+        import json as _json
+        body = _json.loads(resp.body)
+        assert body == {"token": ""}
+
+    @pytest.mark.asyncio
+    async def test_returns_token_for_loopback_when_env_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loopback caller gets {"token": "<hex>"} when JARVIS_API_TOKEN is set."""
+        monkeypatch.setenv("JARVIS_API_TOKEN", _VALID_TOKEN)
+        req = _FakeRequest(ip="127.0.0.1", path="/api/config/token")
+        resp = await config_token_handler(req)  # type: ignore[arg-type]
+        assert resp.status == 200
+        import json as _json
+        body = _json.loads(resp.body)
+        assert body == {"token": _VALID_TOKEN}


### PR DESCRIPTION
## Summary
- New `JARVIS_API_TOKEN` env var gates HTTP, WebSocket, and `/api/config/token` endpoints. `hmac.compare_digest` for timing-safety. Loopback (127.0.0.1, ::1) unconditionally exempted; `/health` always public; CORS `OPTIONS` bypasses auth.
- Backend: `_is_token_auth_enabled`, `_extract_request_token`, `auth_middleware` (HTTP), inline gate in `websocket_handler` BEFORE `ws.prepare()` (WS), plus `GET /api/config/token` (loopback-only diagnostic for the local frontend). `Authorization: Bearer` takes precedence over `?token=` query; debug-log on header/query mismatch.
- Frontend: `core/api/tokenStore.ts` (new) — `getApiToken()` resolves `import.meta.env.VITE_JARVIS_TOKEN` → `localStorage["jarvis_api_token"]` → `""`. `core/api/baseApi.ts` `prepareHeaders` injects `Authorization: Bearer`. `core/websocket/wsClient.ts` `buildWsUrl()` appends `?token=` at socket open while `this.url` stays bare for idempotency.
- Docs: `.env.example` + `frontend/.env.example` document opt-in. `docs/ops/tailscale-setup.md` adds a "Token authentication" section. `CLAUDE.md` extends the auto-notify rule with the bearer-header requirement.

## Opt-in / no regression
With `JARVIS_API_TOKEN` unset, the backend is bitwise-identical to today. Activation:
1. `python -c "import secrets; print(secrets.token_hex(32))"`
2. Backend: set `JARVIS_API_TOKEN=<hex>` in `.env`, restart.
3. Frontend (Vite dev): set `VITE_JARVIS_TOKEN=<hex>` in `frontend/.env`, restart `npm run dev`.
4. Remote browser: `localStorage.setItem("jarvis_api_token", "<hex>")` in DevTools.

## Out of scope (follow-up)
- MCP-side auth middleware (`mcp_auth_middleware`) — punted. MCP server stays `bind_host: 127.0.0.1`. Remote OpenClaw uses an SSH tunnel for now (documented in `docs/ops/tailscale-setup.md`).
- Auto-injection of bearer headers into the OpenClaw MCP registry entry — punted along with the above.
- Token rotation automation, settings UI for token entry — out of scope per spec.

## Tests
- 30 backend tests in `tests/api/test_token_auth.py`.
- 12 frontend tests across `tokenStore.test.ts`, `baseApi.token.test.ts`, `wsClient.token.test.ts`.
- Full backend suite: **1305/1305** passing.
- Reviewer verdict: **PASS** after one fix iteration.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)