### PR TITLE
docs(claude.md): document git credential manager hang + workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,16 @@ If `JARVIS_API_TOKEN` is set on the active backend, the orchestrator MUST add `-
 
 **Failure handling:** wrap the curl in `2>/dev/null || true` so the orchestrator silently no-ops when the JARVIS backend isn't running. Never let a missing notification block the actual work.
 
+## Git push from the sandboxed bash tool
+
+On Windows the Git-for-Windows installer sets `--system credential.helper = manager` (Git Credential Manager). In the Claude Code bash sandbox, GCM tries to open an interactive UI that has no stdin/UI surface — the `git push` then hangs silently with `git-credential-manager get` blocking forever, no error, empty stdout. Symptom: `git push` returns "Command running in background", output file stays empty, `git ls-remote origin <branch>` shows the branch never made it to GitHub.
+
+**Permanent fix (already applied on this machine):** `gh auth setup-git` writes `--global` `credential.https://github.com.helper = !"<path>\gh.exe" auth git-credential`, which overrides GCM only for `github.com` URLs and uses `gh`'s keyring token instead. Verify with `git config --global --get-all credential."https://github.com".helper` — should show two lines (an empty resetter then the gh helper). For other hosts (gitlab, internal corp git) GCM stays active.
+
+**One-shot escape hatch** if the global config is ever wiped or the fix isn't on a fresh machine: `git push https://x-access-token:$(gh auth token)@github.com/<owner>/<repo>.git <branch>:<branch>`. Bypasses the credential helper entirely by embedding the token in the URL. Safe because the URL never gets persisted (it's not stored as a remote).
+
+**If you see a push hang:** check `Get-CimInstance Win32_Process -Filter "Name='git-credential-manager.exe'"` (PowerShell) — if zombie GCM processes are pending, they're the smoking gun. Kill them, run `gh auth setup-git`, retry.
+
 ## Skills
 
 Slash-invocable Skills in `.claude/skills/`. Orchestrator und Subagents nutzen sie statt duplizierter Inline-Commands. Aktuelle Skills:


### PR DESCRIPTION
## Summary
Adds a "Git push from the sandboxed bash tool" section to `CLAUDE.md` documenting the Windows Git Credential Manager hang and how to deal with it:

- **Symptom:** `git push` from the bash tool returns "Command running in background", output stays empty, the branch never reaches GitHub. Zombie `git-credential-manager.exe` processes pile up.
- **Permanent fix:** `gh auth setup-git` writes a `--global` helper for `github.com` URLs that calls `gh auth git-credential` (uses gh's keyring token, no interactive UI).
- **One-shot escape hatch:** `git push https://x-access-token:$(gh auth token)@github.com/<owner>/<repo>.git <branch>:<branch>` — bypasses the credential helper by embedding the token in the URL.
- **Diagnostic:** `Get-CimInstance Win32_Process -Filter "Name='git-credential-manager.exe'"` (PowerShell) — if it lists pending GCM processes, that's the smoking gun.

## Why
This bit me hard during PR #115 — three `git push` attempts hung silently, eating ~5 minutes of debug time before I figured out it was GCM. Documenting it so the next session sees the symptom + fix without re-derivation.

## Verification
This PR itself is the verification — pushed directly with the new helper, no workaround URL, no hang. First clean push from this machine since the fix landed.

## Test plan
- [x] `gh auth setup-git` ran without error.
- [x] `git config --global --get-all credential."https://github.com".helper` shows the gh helper.
- [x] `git push` for this branch succeeded without the embedded-token workaround.
- [x] No new code, no behavior change — `CLAUDE.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)