### PR TITLE
feat(brain): obsidian vault wiring + memory-wiki bridge (#96 phase 2)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,13 @@ jarvis:
   wake_word: "hey jarvis"
   language: "auto"
 
+vault:
+  enabled: true
+  path: "~/Obsidian/jarvis-vault"   # overridable via JARVIS_VAULT_PATH env var
+  rpc_namespace: "wiki"             # OpenClaw RPC namespace prefix
+  fast_path_enabled: true           # fast-path wiki lookup intent (no LLM)
+  fast_path_min_score: 0.75         # min relevance score for fast-path hit
+
 voice_composer:
   max_sentence_words: 50
   long_sentence_mode: "split"   # "split" | "truncate"

--- a/frontend/src/features/brain/__tests__/LedgerInspector.test.tsx
+++ b/frontend/src/features/brain/__tests__/LedgerInspector.test.tsx
@@ -16,7 +16,7 @@ import {
     _mockWsClientImpl,
     installMockWsClient,
 } from '@test/mockWsClient';
-import { MOCK_DEVICE_EVENTS, MOCK_BRAIN_STATE } from '../mock';
+import { MOCK_BRAIN_STATE } from '../mock';
 import { LedgerInspector } from '../components/LedgerInspector/LedgerInspector';
 import brainReducer, { brainInspectorReceived } from '../brainSlice';
 import type { BrainInspectorPayload, DeviceEvent, LedgerKind } from '../types';
@@ -90,7 +90,7 @@ describe('LedgerInspector', () => {
         });
 
         // Inject a new unique event with a payload key unique enough to locate it.
-        // We use a payload message string that does not appear in MOCK_DEVICE_EVENTS.
+        // We use a payload message string that does not appear in MOCK_BRAIN_STATE.recent.
         const newEvent = makeExtraEvent(9999);
         const payload = makeBrainPayload([newEvent]);
 

--- a/frontend/src/features/brain/__tests__/brainSelectors.test.ts
+++ b/frontend/src/features/brain/__tests__/brainSelectors.test.ts
@@ -13,6 +13,7 @@ import {
     selectKindFilter,
     selectSinceFilter,
 } from '../brainSelectors';
+import type { RootState } from '@app';
 import type { BrainState } from '../brainSlice';
 import type { DeviceEvent, LedgerKind } from '../types';
 
@@ -35,7 +36,7 @@ function makeEvent(
     };
 }
 
-function makeState(overrides: Partial<BrainState> = {}): { brain: BrainState } {
+function makeState(overrides: Partial<BrainState> = {}): RootState {
     const base: BrainState = {
         voiceComposerStatus: { last_compose_ts: null, last_salutation: null },
         recent: [],
@@ -43,7 +44,7 @@ function makeState(overrides: Partial<BrainState> = {}): { brain: BrainState } {
         filter: { kinds: [], sinceMs: null },
         lastInspectorTs: null,
     };
-    return { brain: { ...base, ...overrides } };
+    return { brain: { ...base, ...overrides } } as unknown as RootState;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/brain/brainSelectors.ts
+++ b/frontend/src/features/brain/brainSelectors.ts
@@ -1,6 +1,11 @@
 import { createSelector } from '@reduxjs/toolkit';
 import type { RootState } from '@app';
-import type { DeviceEvent, VoiceComposerStatus, LedgerKind, LedgerKindCounts } from './types';
+import type {
+    DeviceEvent,
+    VoiceComposerStatus,
+    LedgerKind,
+    LedgerKindCounts,
+} from './types';
 
 const selectBrainSlice = (state: RootState) => state.brain;
 

--- a/frontend/src/features/brain/index.ts
+++ b/frontend/src/features/brain/index.ts
@@ -3,7 +3,11 @@ export { LedgerInspector } from './components/LedgerInspector';
 export type { LedgerInspectorProps } from './components/LedgerInspector';
 export { useBrain } from './hooks/useBrain';
 export type { UseBrainReturn } from './hooks/useBrain.types';
-export { brainApi, useStreamBrainInspectorQuery, sendLedgerQuery } from './brainApi';
+export {
+    brainApi,
+    useStreamBrainInspectorQuery,
+    sendLedgerQuery,
+} from './brainApi';
 export { brainInspectorReceived, setKindFilter, setSinceFilter } from './brainSlice';
 export type { BrainState } from './brainSlice';
 export {

--- a/frontend/src/features/brain/types.ts
+++ b/frontend/src/features/brain/types.ts
@@ -35,17 +35,17 @@ export interface VoiceComposerStatus {
 
 export type LedgerKindCounts = Partial<Record<LedgerKind, number>>;
 
-export interface BrainInspectorPayload {
-    voice_composer_status: VoiceComposerStatus;
-    /** Last 10 events from backend. */
-    ledger_recent: DeviceEvent[];
-    ledger_count_24h: LedgerKindCounts;
-}
-
 export interface LedgerQueryRequest {
     /** ISO 8601. */
     since: string;
     until: string | null;
     /** Empty array means all kinds. */
     kinds: LedgerKind[];
+}
+
+export interface BrainInspectorPayload {
+    voice_composer_status: VoiceComposerStatus;
+    /** Last 10 events from backend. */
+    ledger_recent: DeviceEvent[];
+    ledger_count_24h: LedgerKindCounts;
 }

--- a/scripts/init_jarvis_vault.sh
+++ b/scripts/init_jarvis_vault.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# init_jarvis_vault.sh — Idempotent initialisation of the JARVIS knowledge vault.
+#
+# Calls `openclaw wiki init` to scaffold the vault directory, then verifies via
+# `openclaw wiki status --json`.  Re-running when already initialised is a no-op.
+#
+# Environment variables:
+#   JARVIS_VAULT_PATH   Override the default vault location (default: ~/Obsidian/jarvis-vault)
+#
+# Exit codes:
+#   0   Vault is initialised (new or pre-existing)
+#   1   Pre-flight check failed (memory-wiki plugin not active) — see instructions
+#   2   Initialisation failed
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve vault path
+# ---------------------------------------------------------------------------
+
+DEFAULT_VAULT_PATH="${HOME}/Obsidian/jarvis-vault"
+RAW_PATH="${JARVIS_VAULT_PATH:-${DEFAULT_VAULT_PATH}}"
+
+# Expand a leading ~ explicitly when the value came from an env var.
+case "${RAW_PATH}" in
+  "~/"*)  VAULT_PATH="${HOME}/${RAW_PATH#~/}" ;;
+  "~")    VAULT_PATH="${HOME}" ;;
+  *)      VAULT_PATH="${RAW_PATH}" ;;
+esac
+
+printf '\n[init_jarvis_vault] vault path: %s\n' "${VAULT_PATH}"
+
+# ---------------------------------------------------------------------------
+# Helper: parse a JSON field with Python (no jq dependency required)
+# ---------------------------------------------------------------------------
+
+_json_field() {
+  local json="$1"
+  local field="$2"
+  python3 -c "
+import json, sys
+try:
+    data = json.loads('''${json}''')
+    val = data.get('${field}')
+    print(str(val).lower() if isinstance(val, bool) else (val or ''))
+except Exception as e:
+    sys.exit(0)
+"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight: verify memory-wiki plugin is active
+# ---------------------------------------------------------------------------
+
+WIKI_STATUS_JSON=""
+if ! WIKI_STATUS_JSON=$(openclaw wiki status --json 2>&1); then
+  printf '\n[init_jarvis_vault] ERROR: `openclaw wiki status --json` failed.\n'
+  printf '\nThe memory-wiki plugin is likely not enabled in your OpenClaw config.\n'
+  printf 'Run the following commands to activate it, then re-run this script:\n\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.vaultMode '"'"'"bridge"'"'"'\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.vault.path '"'"'"~/Obsidian/jarvis-vault"'"'"'\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.vault.renderMode '"'"'"obsidian"'"'"'\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.obsidian.enabled true\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.bridge.enabled true\n'
+  printf '\nThen restart the OpenClaw gateway so the plugin loads:\n'
+  printf '  openclaw daemon restart\n'
+  printf '  # or: systemctl --user restart openclaw-gateway.service\n\n'
+  exit 1
+fi
+
+# Detect "unknown command" output in case openclaw does not recognise `wiki` at all.
+if printf '%s' "${WIKI_STATUS_JSON}" | grep -qi "unknown command"; then
+  printf '\n[init_jarvis_vault] ERROR: `openclaw wiki` command not found.\n'
+  printf 'The memory-wiki plugin is not enabled. Follow the activation steps below:\n\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.vaultMode '"'"'"bridge"'"'"'\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.vault.path '"'"'"~/Obsidian/jarvis-vault"'"'"'\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.vault.renderMode '"'"'"obsidian"'"'"'\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.obsidian.enabled true\n'
+  printf '  openclaw config set plugins.entries.memory-wiki.config.bridge.enabled true\n'
+  printf '  openclaw daemon restart\n\n'
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Idempotency check: already initialised?
+# ---------------------------------------------------------------------------
+
+VAULT_EXISTS=$(_json_field "${WIKI_STATUS_JSON}" "vaultExists" 2>/dev/null || printf "false")
+VAULT_PATH_IN_STATUS=$(_json_field "${WIKI_STATUS_JSON}" "vaultPath" 2>/dev/null || printf "")
+
+if [ "${VAULT_EXISTS}" = "true" ]; then
+  printf '[init_jarvis_vault] Vault already initialised at: %s\n' "${VAULT_PATH_IN_STATUS:-${VAULT_PATH}}"
+  printf '[init_jarvis_vault] Nothing to do — exiting 0.\n\n'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Configure vault path in OpenClaw config (idempotent)
+# ---------------------------------------------------------------------------
+
+printf '[init_jarvis_vault] Configuring vault path in OpenClaw...\n'
+openclaw config set plugins.entries.memory-wiki.config.vault.path "\"${VAULT_PATH}\"" >/dev/null || {
+  printf '[init_jarvis_vault] WARNING: Could not set vault path in config — continuing anyway.\n'
+}
+
+# ---------------------------------------------------------------------------
+# Create the directory and initialise the vault layout
+# ---------------------------------------------------------------------------
+
+printf '[init_jarvis_vault] Creating vault directory: %s\n' "${VAULT_PATH}"
+mkdir -p "${VAULT_PATH}"
+
+printf '[init_jarvis_vault] Running: openclaw wiki init\n'
+if ! openclaw wiki init; then
+  printf '\n[init_jarvis_vault] ERROR: `openclaw wiki init` failed (exit %d).\n' "$?"
+  printf 'Check the output above for details.\n\n'
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Verify: re-read status and assert vaultExists=true
+# ---------------------------------------------------------------------------
+
+printf '[init_jarvis_vault] Verifying initialisation...\n'
+VERIFY_JSON=""
+if ! VERIFY_JSON=$(openclaw wiki status --json 2>&1); then
+  printf '[init_jarvis_vault] ERROR: post-init status check failed.\n'
+  exit 2
+fi
+
+VERIFY_EXISTS=$(_json_field "${VERIFY_JSON}" "vaultExists" 2>/dev/null || printf "false")
+VERIFY_PATH=$(_json_field "${VERIFY_JSON}" "vaultPath" 2>/dev/null || printf "")
+
+if [ "${VERIFY_EXISTS}" != "true" ]; then
+  printf '\n[init_jarvis_vault] ERROR: vault init appeared to succeed but status still reports\n'
+  printf '  vaultExists=false. Manual investigation required.\n\n'
+  exit 2
+fi
+
+printf '\n[init_jarvis_vault] Vault successfully initialised.\n'
+printf '  path: %s\n\n' "${VERIFY_PATH:-${VAULT_PATH}}"
+exit 0

--- a/scripts/install_openclaw.sh
+++ b/scripts/install_openclaw.sh
@@ -98,11 +98,13 @@ DESIRED_MODEL="claude-cli/claude-opus-4-7"
 echo "  - agents.defaults.model = $DESIRED_MODEL"
 openclaw config set agents.defaults.model "$DESIRED_MODEL" >/dev/null
 
-# 3. Disable semantic memory search (needs an embedding provider we don't
-#    configure here). Doctor otherwise prints noisy "no embedding provider
-#    ready" warnings on every run.
-echo "  - agents.defaults.memorySearch.enabled = false"
-openclaw config set agents.defaults.memorySearch.enabled false >/dev/null
+# 3. Enable semantic memory search via memory-core (sqlite-vec + local model).
+#    memory-core provides privacy-friendly local embeddings without requiring an
+#    external API key. The plugin must be present in the openclaw extensions dir.
+#    Set the backend so the agent can perform semantic recall over stored notes.
+echo "  - agents.defaults.memorySearch.enabled = true (via memory-core)"
+openclaw config set agents.defaults.memorySearch.enabled true >/dev/null
+openclaw config set agents.defaults.memorySearch.backend '"memory-core"' >/dev/null
 
 # Restart the gateway so the new config takes effect immediately (no-op
 # if the daemon wasn't running).
@@ -110,6 +112,29 @@ if systemctl --user is-active --quiet openclaw-gateway.service 2>/dev/null; then
     echo "  - restarting openclaw-gateway.service"
     systemctl --user restart openclaw-gateway.service || true
 fi
+
+# --------------------------------------------------------------------------
+# memory-wiki plugin activation (user-run steps — NOT executed by this script)
+# --------------------------------------------------------------------------
+# To enable the memory-wiki plugin (vault search, KnowledgePanel, voice fast-path),
+# run the following commands manually AFTER restarting the openclaw gateway:
+#
+# user-runs:
+#   openclaw config set plugins.entries.memory-wiki.config.vaultMode '"bridge"'
+#   openclaw config set plugins.entries.memory-wiki.config.vault.path '"~/Obsidian/jarvis-vault"'
+#   openclaw config set plugins.entries.memory-wiki.config.vault.renderMode '"obsidian"'
+#   openclaw config set plugins.entries.memory-wiki.config.obsidian.enabled true
+#   openclaw config set plugins.entries.memory-wiki.config.bridge.enabled true
+#
+# Then restart the gateway:
+#   openclaw daemon restart   # or: systemctl --user restart openclaw-gateway.service
+#
+# After activation, run the vault init script:
+#   ./scripts/init_jarvis_vault.sh
+#
+# The above commands are intentionally NOT run here so this script stays
+# idempotent and non-destructive on machines where the plugin is not installed.
+# --------------------------------------------------------------------------
 
 # Run diagnostics
 echo ""
@@ -123,8 +148,10 @@ echo "Next steps:"
 echo "  1. Configure API keys in ~/.openclaw/openclaw.json or ~/.env"
 echo "  2. Start the daemon: openclaw daemon start"
 echo "  3. Verify health: openclaw doctor"
-echo "  4. Generate the voice-cache MP3s (quick-ack fillers, acks, etc.) —"
+echo "  4. (Optional) Enable memory-wiki vault — see the commented block above"
+echo "     in this script for the exact config commands to run by hand."
+echo "  5. Generate the voice-cache MP3s (quick-ack fillers, acks, etc.) —"
 echo "     one-shot, requires FISH_API_KEY + FISH_VOICE_ID in .env:"
 echo "       PYTHONPATH=src .venv/bin/python scripts/generate_voice_cache.py"
-echo "  5. Start JARVIS: PYTHONPATH=src uvicorn main:app --host 0.0.0.0 --port 8000"
+echo "  6. Start JARVIS: PYTHONPATH=src python -m main"
 echo ""

--- a/src/api/ws_server.py
+++ b/src/api/ws_server.py
@@ -43,6 +43,7 @@ from brain.orchestrator import Orchestrator
 from brain.device_ledger import DeviceLedger, DeviceEvent
 from brain.voice_composer import VoiceComposer
 from integrations.openclaw import OpenClawClient
+from integrations.openclaw.wiki_client import WikiClient, WikiClientUnavailableError
 from integrations.spotify import SpotifyClient
 from utils.logger import get_logger
 
@@ -105,6 +106,11 @@ _narration_drainer_task: asyncio.Task[None] | None = None
 _voice_composer: VoiceComposer | None = None
 _device_ledger: DeviceLedger | None = None
 _brain_inspector_task: asyncio.Task[None] | None = None
+
+# Brain Phase 2 — WikiClient + last wiki search state (#106).
+_wiki_client: WikiClient | None = None
+# Shape: {"query": str, "hit_count": int, "ts": str (ISO-8601)} | None
+_last_wiki_search: dict[str, Any] | None = None
 
 # Persona config snapshot — read once at startup so the sleep-phrase closing
 # line can pick a salutation without re-reading config per turn.
@@ -304,11 +310,12 @@ async def broadcast_barge_in() -> None:
 async def broadcast_brain_inspector() -> None:
     """Broadcast a brain_inspector payload to all connected HUD clients.
 
-    Payload includes VoiceComposer status, last 10 ledger events, and
-    per-kind event counts for the last 24 hours.  No-op when no clients
-    are connected.
+    Payload includes VoiceComposer status, last 10 ledger events,
+    per-kind event counts for the last 24 hours, vault_status from the
+    WikiClient, and last_wiki_search state.  No-op when no clients are
+    connected.
     """
-    global _voice_composer, _device_ledger
+    global _voice_composer, _device_ledger, _wiki_client, _last_wiki_search
 
     if not _connected_clients:
         return
@@ -335,10 +342,29 @@ async def broadcast_brain_inspector() -> None:
 
             ledger_count_24h = await _device_ledger.count_since(since_24h)
 
+        # Vault status — poll WikiClient with a 5 s guard; None on failure.
+        vault_status_payload: dict[str, Any] | None = None
+        if _wiki_client is not None:
+            try:
+                ws = await asyncio.wait_for(_wiki_client.status(), timeout=5.0)
+                vault_status_payload = {
+                    "initialised": ws.initialised,
+                    "note_count": ws.note_count,
+                    "last_dream_cycle_at": ws.last_dream_cycle_at,
+                }
+            except asyncio.TimeoutError:
+                logger.warning("broadcast_brain_inspector: wiki.status timed out")
+            except WikiClientUnavailableError as _wce:
+                logger.debug(f"broadcast_brain_inspector: wiki unavailable: {_wce}")
+            except Exception as _we:
+                logger.warning(f"broadcast_brain_inspector: wiki.status error: {_we}")
+
         payload = {
             "voice_composer_status": vc_status,
             "ledger_recent": ledger_recent,
             "ledger_count_24h": ledger_count_24h,
+            "vault_status": vault_status_payload,
+            "last_wiki_search": _last_wiki_search,
         }
         message = json.dumps({"type": "brain_inspector", "payload": payload})
         await _broadcast(message)
@@ -365,6 +391,12 @@ async def _brain_inspector_loop(interval_seconds: float) -> None:
         interval_seconds: Seconds between broadcasts.
     """
     logger.info(f"Brain inspector broadcast loop started (interval={interval_seconds:.0f}s)")
+    # Initial broadcast so consumers don't see stale/empty state for up to
+    # `interval_seconds` after backend restart.
+    try:
+        await broadcast_brain_inspector()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"_brain_inspector_loop initial broadcast failed: {exc}")
     while True:
         try:
             await asyncio.sleep(interval_seconds)
@@ -1832,6 +1864,120 @@ async def jarvis_quiet_handler(request: web.Request) -> web.Response:
         f"HTTP /api/jarvis/quiet: enabled={enabled} quiet_until={quiet_until_iso}"
     )
     return web.json_response({"quiet_until": quiet_until_iso})
+
+
+async def wiki_search_handler(request: web.Request) -> web.Response:
+    """Handle GET /api/brain/wiki/search?q=…&k=… — search the vault.
+
+    Returns ``{"hits": [WikiHit dicts]}``.
+    Responds 400 when query param ``q`` is missing, 503 when the WikiClient
+    is unavailable.
+    """
+    global _wiki_client, _last_wiki_search
+
+    q: str = request.rel_url.query.get("q", "").strip()
+    if not q:
+        return web.json_response({"error": "'q' query parameter is required"}, status=400)
+
+    k_raw = request.rel_url.query.get("k", "6")
+    try:
+        k = max(1, min(20, int(k_raw)))
+    except ValueError:
+        k = 6
+
+    if _wiki_client is None:
+        return web.json_response({"error": "WikiClient not initialised"}, status=503)
+
+    try:
+        hits = await _wiki_client.search(q, k=k)
+    except WikiClientUnavailableError as exc:
+        logger.warning(f"GET /api/brain/wiki/search: unavailable: {exc}")
+        return web.json_response({"error": "knowledge base unavailable"}, status=503)
+
+    hit_dicts = [
+        {
+            "id": h.id,
+            "title": h.title,
+            "score": h.score,
+            "excerpt": h.excerpt,
+            "updated_at": h.updated_at,
+        }
+        for h in hits
+    ]
+
+    # Record last search for brain_inspector broadcast.
+    _last_wiki_search = {
+        "query": q,
+        "hit_count": len(hits),
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+    logger.debug(f"GET /api/brain/wiki/search: q={q!r} hits={len(hits)}")
+    return web.json_response({"hits": hit_dicts})
+
+
+async def wiki_note_handler(request: web.Request) -> web.Response:
+    """Handle GET /api/brain/wiki/note/{note_id} — fetch a single vault note.
+
+    Returns the :class:`WikiNote` as JSON on 200.
+    Responds 404 when the RPC reports the note is not found, 503 on transport
+    failure.
+    """
+    note_id: str = request.match_info.get("note_id", "")
+    if not note_id:
+        return web.json_response({"error": "note_id is required"}, status=400)
+
+    if _wiki_client is None:
+        return web.json_response({"error": "WikiClient not initialised"}, status=503)
+
+    try:
+        note = await _wiki_client.get(note_id)
+    except WikiClientUnavailableError as exc:
+        exc_str = str(exc)
+        # The RPC error message includes "not found" when the note is absent.
+        if "not found" in exc_str.lower():
+            return web.json_response({"error": "note not found"}, status=404)
+        logger.warning(f"GET /api/brain/wiki/note/{note_id}: unavailable: {exc}")
+        return web.json_response({"error": "knowledge base unavailable"}, status=503)
+
+    logger.debug(f"GET /api/brain/wiki/note/{note_id}: ok title={note.title!r}")
+    return web.json_response(
+        {
+            "id": note.id,
+            "title": note.title,
+            "body_md": note.body_md,
+            "backlinks": note.backlinks,
+            "updated_at": note.updated_at,
+        }
+    )
+
+
+async def wiki_obsidian_open_handler(request: web.Request) -> web.Response:
+    """Handle POST /api/brain/wiki/obsidian-open — open a note in Obsidian.
+
+    Accepts ``{"note_id": str}``.  Returns ``{"ok": true}`` on success or
+    503 on failure.
+    """
+    if _wiki_client is None:
+        return web.json_response({"error": "WikiClient not initialised"}, status=503)
+
+    try:
+        data: dict[str, Any] = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+
+    note_id: str = data.get("note_id", "").strip()
+    if not note_id:
+        return web.json_response({"error": "'note_id' is required"}, status=400)
+
+    try:
+        await _wiki_client.obsidian_open(note_id)
+    except WikiClientUnavailableError as exc:
+        logger.warning(f"POST /api/brain/wiki/obsidian-open: unavailable: {exc}")
+        return web.json_response({"error": str(exc)}, status=503)
+
+    logger.debug(f"POST /api/brain/wiki/obsidian-open: note_id={note_id!r}")
+    return web.json_response({"ok": True})
 
 
 async def _broadcast(message: str) -> None:
@@ -4748,7 +4894,7 @@ async def start_ws_server(
     global _calendar_poller_task, _cache_stats_log_task
     global _greeting_played, _last_unread_count, _last_calendar_count
     global _state_machine, _narration_queue, _narration_drainer_task
-    global _voice_composer, _device_ledger, _brain_inspector_task
+    global _voice_composer, _device_ledger, _brain_inspector_task, _wiki_client
 
     # Reset per-boot greeting flag so tests / re-initialisation get a fresh
     # greeting each time start_ws_server is called.
@@ -4960,6 +5106,27 @@ async def start_ws_server(
 
         _set_ledger_hook(_mcp_ledger_hook)
 
+    # Brain Phase 2 — WikiClient (#106).
+    vault_cfg = cfg.get_section("vault") or {}
+    if vault_cfg.get("enabled", True) and _openclaw_client is not None:
+        logger.info("Initialising WikiClient (memory-wiki bridge)...")
+        from integrations.openclaw.ws_client import OpenClawWSClient as _WSClientType  # noqa: PLC0415
+
+        # Access the persistent WS client from the OpenClawClient singleton.
+        _oc_ws_client = getattr(_openclaw_client, "ws_client", None)
+        if _oc_ws_client is not None and isinstance(_oc_ws_client, _WSClientType):
+            _wiki_client = WikiClient(_oc_ws_client)
+            logger.info("WikiClient initialised (reusing openclaw WS connection)")
+        else:
+            logger.warning(
+                "WikiClient: could not obtain OpenClawWSClient from OpenClawClient — "
+                "wiki features disabled. Ensure openclaw.streaming_enabled=true."
+            )
+    else:
+        logger.info(
+            "WikiClient skipped (vault.enabled=false or OpenClaw unavailable)"
+        )
+
     _orchestrator = Orchestrator(
         claude_client=claude_client,
         memory=None,
@@ -4968,6 +5135,7 @@ async def start_ws_server(
         narration_queue=_narration_queue,
         state_machine=_state_machine,
         device_ledger=_device_ledger,
+        wiki_client=_wiki_client,
     )
 
     _intent_parser = get_intent_parser()
@@ -5063,6 +5231,10 @@ async def start_ws_server(
     http_app.router.add_post("/api/jarvis/notify", jarvis_notify_handler)
     http_app.router.add_post("/api/jarvis/status", jarvis_status_handler)
     http_app.router.add_post("/api/jarvis/quiet", jarvis_quiet_handler)
+    # Brain Phase 2 — Wiki endpoints (#106)
+    http_app.router.add_get("/api/brain/wiki/search", wiki_search_handler)
+    http_app.router.add_get("/api/brain/wiki/note/{note_id}", wiki_note_handler)
+    http_app.router.add_post("/api/brain/wiki/obsidian-open", wiki_obsidian_open_handler)
 
     # Start WebSocket server
     ws_runner = web.AppRunner(ws_app)

--- a/src/brain/intent_parser.py
+++ b/src/brain/intent_parser.py
@@ -42,6 +42,7 @@ class Intent(Enum):
     QUIET_MODE_ON = "quiet_mode_on"
     QUIET_MODE_OFF = "quiet_mode_off"
     LEDGER_QUERY = "ledger_query"
+    WIKI_LOOKUP = "wiki_lookup"
 
 
 @dataclass
@@ -566,6 +567,26 @@ INTENT_KEYWORDS: dict[Intent, dict[str, list[str]]] = {
             r"\bzeig\s+mir\s+das\s+ledger\b",
         ],
     },
+    # ------------------------------------------------------------------
+    # Wiki-lookup intent — fast-path vault search, no LLM round-trip.
+    # Triggered by "was weißt du über X" / "what do you know about X".
+    # The topic is extracted by :meth:`IntentParser._extract_wiki_params`.
+    # ------------------------------------------------------------------
+    Intent.WIKI_LOOKUP: {
+        "de": [
+            r"\bwas\s+weißt\s+du\s+(über|zu)\b",
+            r"\bwas\s+weiß\s+du\s+(über|zu)\b",
+            r"\bwas\s+hast\s+du\s+(über|zu)\b",
+            r"\bkennst\s+du\s+(etwas\s+)?(über|zu)\b",
+            r"\bzeig\s+(mir\s+)?was\s+du\s+(über|zu)\s+.+\s+weißt\b",
+        ],
+        "en": [
+            r"\bwhat\s+do\s+you\s+know\s+about\b",
+            r"\bwhat\s+have\s+you\s+learned\s+about\b",
+            r"\bdo\s+you\s+know\s+(anything|something)\s+about\b",
+            r"\btell\s+me\s+what\s+you\s+know\s+about\b",
+        ],
+    },
 }
 
 # ---------------------------------------------------------------------------
@@ -864,6 +885,7 @@ class IntentParser:
             Intent.MORNING_BRIEFING,
             Intent.GREETING,
             Intent.LEDGER_QUERY,
+            Intent.WIKI_LOOKUP,
             Intent.PC_CONTROL,
             Intent.SMART_HOME,
             Intent.EMAIL_COMPOSE,
@@ -970,8 +992,11 @@ class IntentParser:
         )
         _QUIET_MODE_INTENT_BASE = 0.85
         _LEDGER_QUERY_INTENT_BASE = 0.75
+        _WIKI_LOOKUP_INTENT_BASE = 0.80
         if intent in (Intent.QUIET_MODE_ON, Intent.QUIET_MODE_OFF):
             confidence = min(1.0, _QUIET_MODE_INTENT_BASE + (match_count * 0.05))
+        elif intent == Intent.WIKI_LOOKUP:
+            confidence = min(1.0, _WIKI_LOOKUP_INTENT_BASE + (match_count * 0.05))
         elif intent == Intent.LEDGER_QUERY:
             confidence = min(1.0, _LEDGER_QUERY_INTENT_BASE + (match_count * 0.1))
         elif intent in (Intent.EMAIL_READ, Intent.EMAIL_SEARCH, Intent.EMAIL_COMPOSE):
@@ -1019,6 +1044,8 @@ class IntentParser:
             Intent.SPOTIFY_PLAY_CONTEXT,
         ):
             params = self._extract_spotify_params(text, intent)
+        elif intent == Intent.WIKI_LOOKUP:
+            params = self._extract_wiki_params(text)
 
         return confidence, params
 
@@ -1347,6 +1374,40 @@ class IntentParser:
             ).strip()
 
         params["query"] = query.strip()
+        return params
+
+    def _extract_wiki_params(self, text: str) -> dict[str, Any]:
+        """Extract the topic from a wiki-lookup utterance.
+
+        Strips known trigger prefixes so ``params["topic"]`` contains only the
+        subject the user is asking about (e.g. "meine Schwester").
+
+        Args:
+            text: Lowercase user text.
+
+        Returns:
+            Dict with ``topic`` key containing the extracted topic string.
+        """
+        params: dict[str, Any] = {}
+
+        # Ordered from most to least specific so the greedy re.sub picks the
+        # longest matching prefix first.
+        strip_patterns = [
+            r"^was\s+weißt\s+du\s+(über|zu)\s+",
+            r"^was\s+weiß\s+du\s+(über|zu)\s+",
+            r"^was\s+hast\s+du\s+(über|zu)\s+",
+            r"^kennst\s+du\s+(etwas\s+)?(über|zu)\s+",
+            r"^zeig\s+mir\s+was\s+du\s+(über|zu)\s+(.+?)\s+weißt$",
+            r"^what\s+do\s+you\s+know\s+about\s+",
+            r"^what\s+have\s+you\s+learned\s+about\s+",
+            r"^do\s+you\s+know\s+(anything|something)\s+about\s+",
+            r"^tell\s+me\s+what\s+you\s+know\s+about\s+",
+        ]
+        topic = text.strip().rstrip("?!.,;:")
+        for pat in strip_patterns:
+            topic = re.sub(pat, "", topic, flags=re.IGNORECASE).strip()
+
+        params["topic"] = topic.strip().rstrip("?!.,;:")
         return params
 
     def _extract_system_params(self, text: str) -> dict[str, Any]:

--- a/src/brain/orchestrator.py
+++ b/src/brain/orchestrator.py
@@ -15,6 +15,7 @@ session (``SOUL.md`` + session memory).
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 from collections.abc import AsyncGenerator, AsyncIterator
 from dataclasses import dataclass
@@ -87,6 +88,7 @@ class OrchestratorDecision:
 # Spotify intents (SEARCH, QUEUE, PLAY_CONTEXT, and all transport intents)
 # fall through to OpenClaw, which calls the spotify_* MCP tools (issue #87).
 # QUIET_MODE_ON / QUIET_MODE_OFF are handled locally by QuietModeAgent (#93).
+# WIKI_LOOKUP is handled locally when vault fast-path is enabled (#106).
 _LOCAL_INTENTS: frozenset[Intent] = frozenset(
     {
         Intent.SYSTEM,
@@ -96,6 +98,7 @@ _LOCAL_INTENTS: frozenset[Intent] = frozenset(
         Intent.QUIET_MODE_ON,
         Intent.QUIET_MODE_OFF,
         Intent.LEDGER_QUERY,
+        Intent.WIKI_LOOKUP,
     }
 )
 
@@ -117,6 +120,7 @@ class Orchestrator:
         narration_queue: NarrationQueue | None = None,
         state_machine: ConversationStateMachine | None = None,
         device_ledger: DeviceLedger | None = None,
+        wiki_client: Any = None,
     ) -> None:
         """Initialise the orchestrator.
 
@@ -140,6 +144,8 @@ class Orchestrator:
                 shared with the NarrationQueue and the WS server.
             device_ledger: Optional :class:`brain.device_ledger.DeviceLedger` for
                 LEDGER_QUERY fast-path handler.
+            wiki_client: Optional :class:`integrations.openclaw.wiki_client.WikiClient`
+                for WIKI_LOOKUP fast-path handler (#106).
         """
         self.claude_client = claude_client
         self.memory = memory
@@ -148,6 +154,7 @@ class Orchestrator:
         self._narration_queue: NarrationQueue | None = narration_queue
         self._state_machine: ConversationStateMachine | None = state_machine
         self._device_ledger: DeviceLedger | None = device_ledger
+        self._wiki_client: Any = wiki_client  # WikiClient | None
 
         # Config — retained for backward compatibility, but the old
         # "orchestrator_model" / "skip_on_clear_intent" knobs no longer
@@ -563,6 +570,107 @@ class Orchestrator:
 
         return AgentResult(spoken_response=text, success=True)
 
+    async def _handle_wiki_lookup(
+        self,
+        intent_result: IntentResult,
+        language: str,
+    ) -> AgentResult | None:
+        """Handle a WIKI_LOOKUP intent via the vault fast-path.
+
+        Returns ``None`` to fall through to the OpenClaw slow-path when:
+        - fast-path is disabled in config,
+        - WikiClient is not attached,
+        - vault is empty / unavailable,
+        - no hit meets the minimum score threshold.
+
+        Args:
+            intent_result: Classified intent containing ``params["topic"]``.
+            language: Detected language (``"en"`` / ``"de"``).
+
+        Returns:
+            :class:`AgentResult` with a templated spoken response, or ``None``
+            to fall through to the OpenClaw agent.
+        """
+        from integrations.openclaw.wiki_client import WikiClientUnavailableError  # noqa: PLC0415
+
+        cfg = get_config()
+        vault_cfg = cfg.get_section("vault") or {}
+
+        if not vault_cfg.get("fast_path_enabled", True):
+            logger.debug("WIKI_LOOKUP: fast-path disabled in config — falling through")
+            return None
+
+        if self._wiki_client is None:
+            logger.debug("WIKI_LOOKUP: no WikiClient attached — falling through")
+            return None
+
+        topic: str = intent_result.params.get("topic", "").strip()
+        if not topic:
+            logger.debug("WIKI_LOOKUP: empty topic extracted — falling through")
+            return None
+
+        min_score: float = float(vault_cfg.get("fast_path_min_score", 0.75))
+
+        try:
+            hits = await asyncio.wait_for(
+                self._wiki_client.search(topic, k=6),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("WIKI_LOOKUP: search timed out — falling through")
+            return None
+        except WikiClientUnavailableError as exc:
+            logger.warning(f"WIKI_LOOKUP: wiki unavailable — falling through: {exc}")
+            return None
+        except Exception as exc:
+            logger.warning(f"WIKI_LOOKUP: unexpected error — falling through: {exc}")
+            return None
+
+        qualifying = [h for h in hits if h.score >= min_score]
+        if not qualifying:
+            logger.debug(
+                f"WIKI_LOOKUP: no hits above threshold {min_score:.2f} for topic={topic!r}"
+                " — falling through"
+            )
+            return None
+
+        # Format top 1-3 hits into a narration template.
+        top = qualifying[:3]
+        if language == "de":
+            if len(top) == 1:
+                text = (
+                    f"Über {topic} habe ich folgendes gefunden: {top[0].title}. "
+                    f"{top[0].excerpt[:200]}" if top[0].excerpt else
+                    f"Über {topic} habe ich eine Notiz mit dem Titel {top[0].title!r}."
+                )
+            else:
+                titles = ", ".join(h.title for h in top)
+                text = (
+                    f"Über {topic} habe ich {len(top)} Einträge gefunden: {titles}. "
+                    f"Hier der wichtigste: {top[0].excerpt[:200]}" if top[0].excerpt else
+                    f"Über {topic} habe ich unter anderem: {titles}."
+                )
+        else:
+            if len(top) == 1:
+                text = (
+                    f"About {topic}, I found the following: {top[0].title}. "
+                    f"{top[0].excerpt[:200]}" if top[0].excerpt else
+                    f"About {topic}, I have a note titled {top[0].title!r}."
+                )
+            else:
+                titles = ", ".join(h.title for h in top)
+                text = (
+                    f"About {topic}, I found {len(top)} entries: {titles}. "
+                    f"Top result: {top[0].excerpt[:200]}" if top[0].excerpt else
+                    f"About {topic}, I found entries including: {titles}."
+                )
+
+        logger.info(
+            f"WIKI_LOOKUP fast-path: topic={topic!r} hits={len(qualifying)} "
+            f"top_score={top[0].score:.3f}"
+        )
+        return AgentResult(spoken_response=text, success=True)
+
     async def _handle_greeting(
         self,
         text: str,
@@ -732,6 +840,21 @@ class Orchestrator:
             )
             return await self._handle_ledger_query(language)
 
+        # --- WIKI_LOOKUP: fast-path vault search (no LLM, no OpenClaw) ---
+        if (
+            intent_result is not None
+            and intent_result.intent == Intent.WIKI_LOOKUP
+            and intent_result.confidence >= _LOCAL_INTENT_CONFIDENCE
+        ):
+            logger.info(
+                "Local dispatch: wiki_lookup fast-path "
+                f"(conf={intent_result.confidence:.2f})"
+            )
+            result_wl = await self._handle_wiki_lookup(intent_result, language)
+            if result_wl is not None:
+                return result_wl
+            logger.info("WIKI_LOOKUP fast-path miss — falling through to OpenClaw")
+
         # --- Local UI / action commands -------------------------------
         if (
             intent_result is not None
@@ -855,6 +978,28 @@ class Orchestrator:
                 full_text=result_lq.spoken_response,
             )
             return
+
+        # --- WIKI_LOOKUP: fast-path vault search (no LLM, no OpenClaw) --
+        if (
+            intent_result is not None
+            and intent_result.intent == Intent.WIKI_LOOKUP
+            and intent_result.confidence >= _LOCAL_INTENT_CONFIDENCE
+        ):
+            logger.info(
+                "Local dispatch (stream): wiki_lookup fast-path "
+                f"(conf={intent_result.confidence:.2f})"
+            )
+            result_wl = await self._handle_wiki_lookup(intent_result, language)
+            if result_wl is not None:
+                yield StreamChunk(
+                    type="final",
+                    run_id="local",
+                    new_text=result_wl.spoken_response,
+                    full_text=result_wl.spoken_response,
+                )
+                return
+            # Fall through to OpenClaw slow-path when fast-path returns None.
+            logger.info("WIKI_LOOKUP fast-path miss — falling through to OpenClaw")
 
         # --- Local UI / action commands (no streaming, single result) ----
         if (

--- a/src/integrations/openclaw/__init__.py
+++ b/src/integrations/openclaw/__init__.py
@@ -35,6 +35,13 @@ from integrations.openclaw.client import (
     OpenClawNotInstalledError,
     SessionInfo,
 )
+from integrations.openclaw.wiki_client import (
+    WikiClient,
+    WikiClientUnavailableError,
+    WikiHit,
+    WikiNote,
+    WikiStatus,
+)
 from integrations.openclaw.ws_client import OpenClawWSClient, StreamChunk
 
 __all__ = [
@@ -45,4 +52,9 @@ __all__ = [
     "SessionInfo",
     "OpenClawConnectionError",
     "OpenClawNotInstalledError",
+    "WikiClient",
+    "WikiClientUnavailableError",
+    "WikiHit",
+    "WikiNote",
+    "WikiStatus",
 ]

--- a/src/integrations/openclaw/wiki_client.py
+++ b/src/integrations/openclaw/wiki_client.py
@@ -1,0 +1,296 @@
+"""WikiClient — async read-only bridge to OpenClaw's memory-wiki RPC namespace.
+
+Sends ``wiki.*`` RPC calls over the existing :class:`OpenClawWSClient` connection.
+No second WebSocket connection is created; this client piggybacks on the
+singleton gateway connection managed by :mod:`integrations.openclaw.ws_client`.
+
+All public methods time out after 5 seconds and map errors to
+:class:`WikiClientUnavailableError` so callers can return HTTP 503 cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from integrations.openclaw.ws_client import OpenClawWSClient
+
+logger = get_logger("wiki_client")
+
+# Per-call timeout — generous enough for a cold-start vault scan, tight enough
+# to not block the brain_inspector broadcast cycle.
+_RPC_TIMEOUT_S: float = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WikiHit:
+    """A single search result returned by ``wiki.search``."""
+
+    id: str
+    title: str
+    score: float
+    excerpt: str
+    updated_at: str
+
+
+@dataclass
+class WikiNote:
+    """Full note content returned by ``wiki.get``."""
+
+    id: str
+    title: str
+    body_md: str
+    backlinks: list[str] = field(default_factory=list)
+    updated_at: str = ""
+
+
+@dataclass
+class WikiStatus:
+    """Vault status summary returned by ``wiki.status``."""
+
+    initialised: bool
+    note_count: int
+    last_dream_cycle_at: str | None
+    path: str | None = None
+    render_mode: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Error
+# ---------------------------------------------------------------------------
+
+
+class WikiClientUnavailableError(RuntimeError):
+    """Raised when the wiki RPC is unavailable or returns an error."""
+
+
+# ---------------------------------------------------------------------------
+# Main client
+# ---------------------------------------------------------------------------
+
+
+class WikiClient:
+    """Read-only async bridge to OpenClaw's ``wiki.*`` RPC namespace.
+
+    Wraps the shared :class:`~integrations.openclaw.ws_client.OpenClawWSClient`
+    gateway connection; no additional transport is opened.  All methods apply a
+    5 s timeout and raise :class:`WikiClientUnavailableError` on any failure so
+    callers can return HTTP 503 cleanly.
+
+    Attributes:
+        _ws_client: The shared OpenClaw WS client singleton.
+    """
+
+    def __init__(self, ws_client: OpenClawWSClient) -> None:
+        """Initialise with the shared OpenClaw WS client.
+
+        Args:
+            ws_client: Already-constructed (and optionally connected)
+                :class:`~integrations.openclaw.ws_client.OpenClawWSClient`
+                singleton.  The WikiClient does not manage the connection
+                lifecycle; callers must ensure ``ws_client.connect()`` has been
+                awaited before issuing wiki calls.
+        """
+        self._ws_client = ws_client
+
+    # ── Public API ──────────────────────────────────────────────────────────
+
+    async def search(self, query: str, k: int = 6) -> list[WikiHit]:
+        """Search the wiki vault and return up to *k* ranked hits.
+
+        Args:
+            query: Free-text search query.
+            k: Maximum number of results to return (default 6).
+
+        Returns:
+            List of :class:`WikiHit` sorted by descending relevance score.
+            May be empty when the vault is unseeded.
+
+        Raises:
+            WikiClientUnavailableError: On timeout, connection error, or RPC error.
+        """
+        try:
+            result = await asyncio.wait_for(
+                self._call("wiki.search", {"query": query, "maxResults": k}),
+                timeout=_RPC_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as exc:
+            raise WikiClientUnavailableError(
+                f"wiki.search timed out after {_RPC_TIMEOUT_S}s"
+            ) from exc
+        except WikiClientUnavailableError:
+            raise
+        except Exception as exc:
+            raise WikiClientUnavailableError(f"wiki.search failed: {exc}") from exc
+
+        hits: list[WikiHit] = []
+        for item in result if isinstance(result, list) else []:
+            hits.append(
+                WikiHit(
+                    id=str(item.get("id") or item.get("path") or ""),
+                    title=str(item.get("title") or ""),
+                    score=float(item.get("score") or 0.0),
+                    excerpt=str(item.get("snippet") or ""),
+                    updated_at=str(item.get("updatedAt") or ""),
+                )
+            )
+        return hits
+
+    async def get(self, note_id: str) -> WikiNote:
+        """Fetch a single note by its path/id.
+
+        Args:
+            note_id: The vault-relative path or ID of the note (as returned
+                in :attr:`WikiHit.id`).
+
+        Returns:
+            :class:`WikiNote` with the full markdown body.
+
+        Raises:
+            WikiClientUnavailableError: On timeout, connection error, or when
+                the note is not found (RPC error).
+        """
+        try:
+            result = await asyncio.wait_for(
+                self._call("wiki.get", {"lookup": note_id}),
+                timeout=_RPC_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as exc:
+            raise WikiClientUnavailableError(
+                f"wiki.get timed out after {_RPC_TIMEOUT_S}s"
+            ) from exc
+        except WikiClientUnavailableError:
+            raise
+        except Exception as exc:
+            raise WikiClientUnavailableError(f"wiki.get failed: {exc}") from exc
+
+        if not isinstance(result, dict):
+            raise WikiClientUnavailableError(
+                f"wiki.get returned unexpected type: {type(result).__name__}"
+            )
+
+        return WikiNote(
+            id=str(result.get("id") or result.get("path") or note_id),
+            title=str(result.get("title") or ""),
+            body_md=str(result.get("content") or ""),
+            backlinks=[],
+            updated_at=str(result.get("updatedAt") or ""),
+        )
+
+    async def status(self) -> WikiStatus:
+        """Fetch the current vault status from the OpenClaw plugin.
+
+        Returns:
+            :class:`WikiStatus` reflecting the current vault state.
+
+        Raises:
+            WikiClientUnavailableError: On timeout, connection error, or RPC error.
+        """
+        try:
+            result = await asyncio.wait_for(
+                self._call("wiki.status", {}),
+                timeout=_RPC_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as exc:
+            raise WikiClientUnavailableError(
+                f"wiki.status timed out after {_RPC_TIMEOUT_S}s"
+            ) from exc
+        except WikiClientUnavailableError:
+            raise
+        except Exception as exc:
+            raise WikiClientUnavailableError(f"wiki.status failed: {exc}") from exc
+
+        if not isinstance(result, dict):
+            raise WikiClientUnavailableError(
+                f"wiki.status returned unexpected type: {type(result).__name__}"
+            )
+
+        page_counts: dict[str, int] = result.get("pageCounts") or {}
+        total_notes = sum(page_counts.values())
+        vault_exists: bool = bool(result.get("vaultExists", False))
+
+        return WikiStatus(
+            initialised=vault_exists,
+            note_count=total_notes,
+            last_dream_cycle_at=None,  # memory-wiki does not expose dream cycle ts yet
+            path=str(result.get("vaultPath") or ""),
+            render_mode=str(result.get("renderMode") or ""),
+        )
+
+    async def obsidian_open(self, note_id: str) -> bool:
+        """Request Obsidian to open the given vault path.
+
+        Args:
+            note_id: The vault-relative file path (``WikiHit.id``) to open.
+
+        Returns:
+            ``True`` when Obsidian accepted the open request.
+
+        Raises:
+            WikiClientUnavailableError: On timeout, connection error, or when
+                Obsidian is not installed / not running.
+        """
+        try:
+            await asyncio.wait_for(
+                self._call("wiki.obsidian.open", {"path": note_id}),
+                timeout=_RPC_TIMEOUT_S,
+            )
+            return True
+        except asyncio.TimeoutError as exc:
+            raise WikiClientUnavailableError(
+                f"wiki.obsidian.open timed out after {_RPC_TIMEOUT_S}s"
+            ) from exc
+        except WikiClientUnavailableError:
+            raise
+        except Exception as exc:
+            raise WikiClientUnavailableError(
+                f"wiki.obsidian.open failed: {exc}"
+            ) from exc
+
+    # ── Internal RPC helper ─────────────────────────────────────────────────
+
+    async def _call(self, method: str, params: dict[str, Any]) -> Any:
+        """Send a gateway RPC and await the response.
+
+        Uses the shared WS connection via a pending-RPC registry on the client.
+        Falls back to :meth:`~integrations.openclaw.ws_client.OpenClawWSClient.call_rpc`
+        which this module extends onto the client if not present.
+
+        Args:
+            method: Gateway RPC method name (e.g. ``"wiki.search"``).
+            params: RPC parameter dict.
+
+        Returns:
+            The ``payload`` field from the gateway response.
+
+        Raises:
+            WikiClientUnavailableError: When the gateway is not connected or
+                returns an error response.
+        """
+        if not self._ws_client.is_connected:
+            try:
+                await self._ws_client.connect()
+            except Exception as exc:
+                raise WikiClientUnavailableError(
+                    f"Cannot connect to OpenClaw gateway: {exc}"
+                ) from exc
+
+        try:
+            return await self._ws_client.call_rpc(method, params)
+        except WikiClientUnavailableError:
+            raise
+        except Exception as exc:
+            raise WikiClientUnavailableError(
+                f"RPC {method!r} failed: {exc}"
+            ) from exc

--- a/src/integrations/openclaw/ws_client.py
+++ b/src/integrations/openclaw/ws_client.py
@@ -288,6 +288,9 @@ class OpenClawWSClient:
         # run_id → cumulative full_text seen so far (used to compute new_text).
         self._prev_texts: dict[str, str] = {}
 
+        # req_id → Future for non-streaming RPC calls (wiki.*, etc.).
+        self._pending_rpc: dict[str, asyncio.Future[dict[str, Any]]] = {}
+
         # Session IDs we are currently subscribed to (resubscribe on reconnect).
         self._subscribed_sessions: set[str] = set()
 
@@ -351,6 +354,13 @@ class OpenClawWSClient:
             )
         self._pending_runs.clear()
         self._prev_texts.clear()
+
+        # Reject all pending non-streaming RPC futures.
+        for req_id, fut in list(self._pending_rpc.items()):
+            if not fut.done():
+                fut.set_exception(RuntimeError("connection_closed"))
+        self._pending_rpc.clear()
+
         logger.info("OpenClaw WS client closed")
 
     async def query_agent_stream(
@@ -440,6 +450,48 @@ class OpenClawWSClient:
         finally:
             self._pending_runs.pop(run_id, None)
             self._prev_texts.pop(run_id, None)
+
+    async def call_rpc(self, method: str, params: dict[str, Any]) -> Any:
+        """Send a non-streaming gateway RPC call and await the response payload.
+
+        Suitable for ``wiki.*`` and other request/response gateway methods that
+        return a single response frame rather than a stream of ``chat`` events.
+
+        Uses the same shared WS connection as :meth:`query_agent_stream`.
+        Concurrent callers are multiplexed via per-request asyncio Futures.
+
+        Args:
+            method: Gateway RPC method name (e.g. ``"wiki.search"``).
+            params: RPC parameter dict.
+
+        Returns:
+            The ``payload`` field from the gateway response frame.
+
+        Raises:
+            RuntimeError: When not connected and reconnect fails.
+            RuntimeError: When the gateway returns ``ok=False``.
+        """
+        if not self._connected:
+            await self.connect()
+
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
+        frame_json, req_id = _make_request(method, params)
+        self._pending_rpc[req_id] = future
+
+        try:
+            await self._send(frame_json)
+            logger.debug(f"RPC sent method={method!r} req_id={req_id}")
+            resp = await future
+        finally:
+            self._pending_rpc.pop(req_id, None)
+
+        ok = resp.get("ok", False)
+        if not ok:
+            err = resp.get("error") or resp.get("payload") or resp
+            raise RuntimeError(f"Gateway RPC {method!r} failed: {err}")
+
+        return resp.get("payload")
 
     async def abort(self, session_id: str, run_id: str) -> None:
         """Send a ``chat.abort`` RPC to cancel a running turn.
@@ -634,6 +686,13 @@ class OpenClawWSClient:
                 )
             self._pending_runs.clear()
             self._prev_texts.clear()
+
+            # Reject all pending non-streaming RPC futures so callers don't hang.
+            for _req_id, _fut in list(self._pending_rpc.items()):
+                if not _fut.done():
+                    _fut.set_exception(RuntimeError("connection_lost"))
+            self._pending_rpc.clear()
+
             asyncio.create_task(self._reconnect_loop(), name="openclaw-ws-reconnect")
 
     async def _dispatch(self, msg: dict[str, Any]) -> None:
@@ -642,6 +701,15 @@ class OpenClawWSClient:
 
         # Heartbeat — ignore.
         if event == "tick":
+            return
+
+        # Non-streaming RPC responses carry a top-level ``id`` that matches
+        # the request frame sent by :meth:`call_rpc`. Resolve the Future.
+        msg_id: str | None = msg.get("id")
+        if msg_id and msg_id in self._pending_rpc:
+            future = self._pending_rpc.pop(msg_id)
+            if not future.done():
+                future.set_result(msg)
             return
 
         if event != "chat":

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -171,6 +171,21 @@ class ConfigLoader:
         if gateway_url := os.environ.get("OPENCLAW_GATEWAY_URL"):
             self._config.setdefault("openclaw", {})["gateway_url"] = gateway_url
 
+        # Override vault path from env (JARVIS_VAULT_PATH takes precedence over YAML).
+        if vault_path := os.environ.get("JARVIS_VAULT_PATH"):
+            self._config.setdefault("vault", {})["path"] = vault_path
+
+        # Expand ~ in vault.path after all env overrides are applied so that
+        # both the YAML default and the env-var override are normalised.
+        vault_section = self._config.get("vault")
+        if isinstance(vault_section, dict):
+            raw_path: str = vault_section.get("path", "")
+            if raw_path:
+                try:
+                    vault_section["path"] = os.path.expanduser(raw_path)
+                except Exception:
+                    pass  # leave raw_path as-is; startup will surface the error
+
     def get(self, key: str, default: Any = None) -> Any:
         """Get a configuration value by dot-notation key.
 

--- a/tests/api/test_ws_server_brain.py
+++ b/tests/api/test_ws_server_brain.py
@@ -252,6 +252,85 @@ class TestBrainInspectorBroadcast:
         # broadcast_brain_inspector should have been called at least once.
         assert len(broadcast_calls) >= 1
 
+    @pytest.mark.asyncio
+    async def test_brain_inspector_loop_broadcasts_immediately_before_first_sleep(self):
+        """_brain_inspector_loop fires broadcast_brain_inspector once before the first sleep.
+
+        Ordering assertion: the initial call happens before any asyncio.sleep, so
+        cancelling the task *before* the interval elapses should still record exactly
+        one broadcast.
+        """
+        broadcast_mock = AsyncMock()
+        sleep_mock = AsyncMock(side_effect=asyncio.CancelledError)
+
+        with (
+            patch.object(mod, "broadcast_brain_inspector", broadcast_mock),
+            patch("api.ws_server.asyncio.sleep", sleep_mock),
+        ):
+            task = asyncio.create_task(mod._brain_inspector_loop(0.05))
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # The initial broadcast must have happened before any sleep was awaited.
+        broadcast_mock.assert_awaited_once()
+        # sleep was called exactly once (the loop's first iteration sleep, which
+        # immediately raised CancelledError ending the loop).
+        sleep_mock.assert_awaited_once_with(0.05)
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_loop_cancellation_does_not_rebroadcast(self):
+        """After CancelledError the loop exits without an extra broadcast call."""
+        call_count = 0
+
+        async def _counting_broadcast() -> None:
+            nonlocal call_count
+            call_count += 1
+
+        interval = 0.05
+
+        with patch.object(mod, "broadcast_brain_inspector", _counting_broadcast):
+            task = asyncio.create_task(mod._brain_inspector_loop(interval))
+            # Let the initial broadcast fire, then cancel before the first interval.
+            await asyncio.sleep(0.01)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Only the initial broadcast should have fired (interval not yet elapsed).
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_loop_initial_broadcast_failure_does_not_crash_loop(self):
+        """A transient error in the initial broadcast must not prevent the loop from running."""
+        calls: list[str] = []
+        first_call = True
+
+        async def _flaky_broadcast() -> None:
+            nonlocal first_call
+            if first_call:
+                first_call = False
+                raise RuntimeError("transient startup failure")
+            calls.append("ok")
+
+        interval = 0.05
+
+        with patch.object(mod, "broadcast_brain_inspector", _flaky_broadcast):
+            task = asyncio.create_task(mod._brain_inspector_loop(interval))
+            # Wait for more than one interval so the loop's normal cycle runs.
+            await asyncio.sleep(interval * 2.5)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Loop continued and broadcast succeeded on the regular cycle.
+        assert len(calls) >= 1
+
 
 # ---------------------------------------------------------------------------
 # AC #7 — tts_emitted row includes correct char_count.

--- a/tests/api/test_ws_server_wiki_routes.py
+++ b/tests/api/test_ws_server_wiki_routes.py
@@ -1,0 +1,628 @@
+"""Tests for the three aiohttp wiki REST handlers in api.ws_server.
+
+Covers:
+- GET /api/brain/wiki/search  (AC #7 — HTTP 200, 400, 503)
+- GET /api/brain/wiki/note/{note_id}  (AC #8 — HTTP 200, 404, 503)
+- POST /api/brain/wiki/obsidian-open  (AC #15, #16 — HTTP 200, 400, 503)
+- vault_status + last_wiki_search flow into broadcast_brain_inspector (AC #13)
+
+All external I/O is mocked; no live OpenClaw gateway or HTTP server required
+for the route handler tests.  Uses aiohttp.test_utils.TestServer + TestClient
+following the pattern established by tests/api/test_spotify_routes.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import api.ws_server as mod
+from integrations.openclaw.wiki_client import (
+    WikiClientUnavailableError,
+    WikiHit,
+    WikiNote,
+    WikiStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_wiki_hit(
+    note_id: str = "notes/sister",
+    title: str = "Schwester",
+    score: float = 0.92,
+    excerpt: str = "Geburtstag am 12. Juni.",
+    updated_at: str = "2025-01-15T10:00:00Z",
+) -> WikiHit:
+    return WikiHit(
+        id=note_id,
+        title=title,
+        score=score,
+        excerpt=excerpt,
+        updated_at=updated_at,
+    )
+
+
+def _make_wiki_note(
+    note_id: str = "notes/sister",
+    title: str = "Schwester",
+    body_md: str = "# Schwester\n\nGeburtstag am 12. Juni.",
+    updated_at: str = "2025-01-15T10:00:00Z",
+) -> WikiNote:
+    return WikiNote(
+        id=note_id,
+        title=title,
+        body_md=body_md,
+        backlinks=[],
+        updated_at=updated_at,
+    )
+
+
+def _make_wiki_status(
+    initialised: bool = True,
+    note_count: int = 42,
+    path: str = "/home/user/Obsidian/jarvis-vault",
+    render_mode: str = "obsidian",
+) -> WikiStatus:
+    return WikiStatus(
+        initialised=initialised,
+        note_count=note_count,
+        last_dream_cycle_at=None,
+        path=path,
+        render_mode=render_mode,
+    )
+
+
+def _make_mock_wiki_client(
+    search_return: list[WikiHit] | None = None,
+    get_return: WikiNote | None = None,
+    status_return: WikiStatus | None = None,
+) -> MagicMock:
+    """Return a MagicMock shaped like WikiClient."""
+    mock = MagicMock()
+    mock.search = AsyncMock(return_value=search_return or [])
+    mock.get = AsyncMock(return_value=get_return or _make_wiki_note())
+    mock.status = AsyncMock(return_value=status_return or _make_wiki_status())
+    mock.obsidian_open = AsyncMock(return_value=True)
+    return mock
+
+
+async def _build_wiki_app() -> web.Application:
+    """Build a minimal aiohttp app with only wiki route handlers."""
+    from api.ws_server import (
+        wiki_note_handler,
+        wiki_obsidian_open_handler,
+        wiki_search_handler,
+    )
+
+    app = web.Application()
+    app.router.add_get("/api/brain/wiki/search", wiki_search_handler)
+    app.router.add_get("/api/brain/wiki/note/{note_id}", wiki_note_handler)
+    app.router.add_post("/api/brain/wiki/obsidian-open", wiki_obsidian_open_handler)
+    return app
+
+
+@asynccontextmanager
+async def _client_ctx(wiki_client: MagicMock | None, last_wiki_search: dict | None = None):
+    """Spin up TestClient patching _wiki_client and _last_wiki_search on the module."""
+    app = await _build_wiki_app()
+    server = TestServer(app)
+    client = TestClient(server)
+
+    with (
+        patch.object(mod, "_wiki_client", wiki_client),
+        patch.object(mod, "_last_wiki_search", last_wiki_search),
+    ):
+        await client.start_server()
+        try:
+            yield client
+        finally:
+            await client.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/brain/wiki/search
+# ---------------------------------------------------------------------------
+
+
+class TestWikiSearchHandler:
+    """Tests for GET /api/brain/wiki/search."""
+
+    @pytest.mark.asyncio
+    async def test_search_happy_path_returns_200_with_hits(self):
+        """Happy path: returns 200 with non-empty hits array."""
+        hit = _make_wiki_hit()
+        mock_client = _make_mock_wiki_client(search_return=[hit])
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/search?q=test")
+            assert resp.status == 200
+            body = await resp.json()
+            assert "hits" in body
+            assert len(body["hits"]) == 1
+            assert body["hits"][0]["id"] == "notes/sister"
+            assert body["hits"][0]["title"] == "Schwester"
+            assert body["hits"][0]["score"] == 0.92
+
+    @pytest.mark.asyncio
+    async def test_search_missing_q_returns_400(self):
+        """Missing 'q' parameter returns 400."""
+        mock_client = _make_mock_wiki_client()
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/search")
+            assert resp.status == 400
+            body = await resp.json()
+            assert "error" in body
+
+    @pytest.mark.asyncio
+    async def test_search_empty_q_returns_400(self):
+        """Blank 'q' parameter (whitespace only) returns 400."""
+        mock_client = _make_mock_wiki_client()
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/search?q=   ")
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_search_wiki_client_none_returns_503(self):
+        """_wiki_client is None → 503."""
+        async with _client_ctx(None) as client:
+            resp = await client.get("/api/brain/wiki/search?q=test")
+            assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_search_wiki_unavailable_error_returns_503(self):
+        """WikiClientUnavailableError from search() → 503."""
+        mock_client = _make_mock_wiki_client()
+        mock_client.search = AsyncMock(
+            side_effect=WikiClientUnavailableError("connection lost")
+        )
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/search?q=test")
+            assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_search_updates_last_wiki_search_on_success(self):
+        """Successful search sets _last_wiki_search with query, hit_count, ts."""
+        hit = _make_wiki_hit()
+        mock_client = _make_mock_wiki_client(search_return=[hit])
+
+        # Save and reset _last_wiki_search to None before request.
+        saved = mod._last_wiki_search
+        mod._last_wiki_search = None
+        try:
+            app = await _build_wiki_app()
+            server = TestServer(app)
+            http_client = TestClient(server)
+
+            with patch.object(mod, "_wiki_client", mock_client):
+                await http_client.start_server()
+                try:
+                    await http_client.get("/api/brain/wiki/search?q=Schwester")
+                finally:
+                    await http_client.close()
+
+            # _last_wiki_search should now be set.
+            assert mod._last_wiki_search is not None
+            assert mod._last_wiki_search["query"] == "Schwester"
+            assert mod._last_wiki_search["hit_count"] == 1
+            assert "ts" in mod._last_wiki_search
+        finally:
+            # Restore original value.
+            mod._last_wiki_search = saved
+
+    @pytest.mark.asyncio
+    async def test_search_last_wiki_search_not_updated_on_error(self):
+        """Failed search does NOT update _last_wiki_search."""
+        mock_client = _make_mock_wiki_client()
+        mock_client.search = AsyncMock(side_effect=WikiClientUnavailableError("nope"))
+
+        original_last = {"query": "old", "hit_count": 0, "ts": "old-ts"}
+
+        saved = mod._last_wiki_search
+        mod._last_wiki_search = original_last
+        try:
+            app = await _build_wiki_app()
+            server = TestServer(app)
+            http_client = TestClient(server)
+            with patch.object(mod, "_wiki_client", mock_client):
+                await http_client.start_server()
+                try:
+                    await http_client.get("/api/brain/wiki/search?q=test")
+                finally:
+                    await http_client.close()
+
+            # _last_wiki_search should still be the original (unchanged).
+            assert mod._last_wiki_search == original_last
+        finally:
+            mod._last_wiki_search = saved
+
+    @pytest.mark.asyncio
+    async def test_search_k_parameter_clamped_to_valid_range(self):
+        """k is clamped to [1, 20]; handler still returns 200."""
+        mock_client = _make_mock_wiki_client(search_return=[])
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/search?q=test&k=100")
+            assert resp.status == 200
+            # k was clamped — search was still called.
+            mock_client.search.assert_awaited_once()
+            call_args = mock_client.search.call_args
+            # k may be a positional or keyword argument.
+            positional_args = call_args[0] if call_args[0] else ()
+            keyword_args = call_args[1] if call_args[1] else {}
+            if len(positional_args) >= 2:
+                k_arg = positional_args[1]
+            else:
+                k_arg = keyword_args.get("k", None)
+            # k should be clamped to 20
+            assert k_arg is not None
+            assert k_arg <= 20
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_k_defaults_to_6(self):
+        """Non-numeric k falls back to 6."""
+        mock_client = _make_mock_wiki_client(search_return=[])
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/search?q=test&k=notanumber")
+            assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/brain/wiki/note/{note_id}
+# ---------------------------------------------------------------------------
+
+
+class TestWikiNoteHandler:
+    """Tests for GET /api/brain/wiki/note/{note_id}."""
+
+    @pytest.mark.asyncio
+    async def test_note_happy_path_returns_200_with_note(self):
+        """Happy path: returns 200 with full note body."""
+        note = _make_wiki_note()
+        mock_client = _make_mock_wiki_client(get_return=note)
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/note/notes%2Fsister")
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["id"] == "notes/sister"
+            assert body["title"] == "Schwester"
+            assert "Geburtstag" in body["body_md"]
+
+    @pytest.mark.asyncio
+    async def test_note_wiki_client_none_returns_503(self):
+        """_wiki_client is None → 503."""
+        async with _client_ctx(None) as client:
+            resp = await client.get("/api/brain/wiki/note/some-note")
+            assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_note_not_found_returns_404(self):
+        """WikiClientUnavailableError with 'not found' in message → 404."""
+        mock_client = _make_mock_wiki_client()
+        mock_client.get = AsyncMock(
+            side_effect=WikiClientUnavailableError("Note not found in vault")
+        )
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/note/missing")
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_note_other_unavailable_error_returns_503(self):
+        """WikiClientUnavailableError without 'not found' → 503."""
+        mock_client = _make_mock_wiki_client()
+        mock_client.get = AsyncMock(
+            side_effect=WikiClientUnavailableError("connection reset")
+        )
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/note/some-note")
+            assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_note_response_includes_required_fields(self):
+        """Response JSON includes id, title, body_md, backlinks, updated_at."""
+        note = _make_wiki_note()
+        mock_client = _make_mock_wiki_client(get_return=note)
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.get("/api/brain/wiki/note/notes%2Fsister")
+            body = await resp.json()
+
+        for field in ("id", "title", "body_md", "backlinks", "updated_at"):
+            assert field in body, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/brain/wiki/obsidian-open
+# ---------------------------------------------------------------------------
+
+
+class TestWikiObsidianOpenHandler:
+    """Tests for POST /api/brain/wiki/obsidian-open."""
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_happy_path_returns_200_ok(self):
+        """Happy path: returns 200 with {ok: true}."""
+        mock_client = _make_mock_wiki_client()
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.post(
+                "/api/brain/wiki/obsidian-open",
+                json={"note_id": "notes/sister"},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_missing_note_id_returns_400(self):
+        """Missing note_id in body → 400."""
+        mock_client = _make_mock_wiki_client()
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.post(
+                "/api/brain/wiki/obsidian-open",
+                json={},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_empty_note_id_returns_400(self):
+        """Blank note_id in body → 400."""
+        mock_client = _make_mock_wiki_client()
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.post(
+                "/api/brain/wiki/obsidian-open",
+                json={"note_id": "   "},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_wiki_client_none_returns_503(self):
+        """_wiki_client is None → 503."""
+        async with _client_ctx(None) as client:
+            resp = await client.post(
+                "/api/brain/wiki/obsidian-open",
+                json={"note_id": "notes/sister"},
+            )
+            assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_unavailable_error_returns_503(self):
+        """WikiClientUnavailableError from obsidian_open() → 503."""
+        mock_client = _make_mock_wiki_client()
+        mock_client.obsidian_open = AsyncMock(
+            side_effect=WikiClientUnavailableError("Obsidian not running")
+        )
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.post(
+                "/api/brain/wiki/obsidian-open",
+                json={"note_id": "notes/sister"},
+            )
+            assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_invalid_json_body_returns_400(self):
+        """Malformed JSON body → 400."""
+        mock_client = _make_mock_wiki_client()
+
+        async with _client_ctx(mock_client) as client:
+            resp = await client.post(
+                "/api/brain/wiki/obsidian-open",
+                data=b"not-json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# broadcast_brain_inspector — vault_status and last_wiki_search
+# (AC #13: verifies fields flow into the payload)
+# ---------------------------------------------------------------------------
+
+
+class _FakeWs:
+    """Minimal WebSocket stand-in that captures sent messages."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send_str(self, message: str) -> None:
+        self.sent.append(message)
+
+
+class TestBrainInspectorWikiFields:
+    """Verify vault_status + last_wiki_search appear in brain_inspector payload."""
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_includes_vault_status_key(self):
+        """broadcast_brain_inspector() payload always has a 'vault_status' key."""
+        from brain.device_ledger import DeviceLedger
+        from brain.voice_composer import VoiceComposer
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = str(Path(td) / "bi_wiki.db")
+            dl = DeviceLedger(db_path=db_file)
+            await dl.init()
+            vc = VoiceComposer(config={})
+
+            fake_ws = _FakeWs()
+            mod._connected_clients.add(fake_ws)
+
+            try:
+                with (
+                    patch.object(mod, "_voice_composer", vc),
+                    patch.object(mod, "_device_ledger", dl),
+                    patch.object(mod, "_wiki_client", None),
+                    patch.object(mod, "_last_wiki_search", None),
+                ):
+                    await mod.broadcast_brain_inspector()
+            finally:
+                mod._connected_clients.discard(fake_ws)
+
+        assert len(fake_ws.sent) == 1
+        payload = json.loads(fake_ws.sent[0])["payload"]
+        assert "vault_status" in payload
+        assert payload["vault_status"] is None  # _wiki_client is None
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_vault_status_populated_from_wiki_client(self):
+        """vault_status is populated when WikiClient.status() returns successfully."""
+        from brain.device_ledger import DeviceLedger
+        from brain.voice_composer import VoiceComposer
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = str(Path(td) / "bi_wiki_populated.db")
+            dl = DeviceLedger(db_path=db_file)
+            await dl.init()
+            vc = VoiceComposer(config={})
+
+            mock_wiki = _make_mock_wiki_client(
+                status_return=_make_wiki_status(initialised=True, note_count=50)
+            )
+
+            fake_ws = _FakeWs()
+            mod._connected_clients.add(fake_ws)
+
+            try:
+                with (
+                    patch.object(mod, "_voice_composer", vc),
+                    patch.object(mod, "_device_ledger", dl),
+                    patch.object(mod, "_wiki_client", mock_wiki),
+                    patch.object(mod, "_last_wiki_search", None),
+                ):
+                    await mod.broadcast_brain_inspector()
+            finally:
+                mod._connected_clients.discard(fake_ws)
+
+        payload = json.loads(fake_ws.sent[0])["payload"]
+        vs = payload["vault_status"]
+        assert vs is not None
+        assert vs["initialised"] is True
+        assert vs["note_count"] == 50
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_vault_status_none_on_wiki_unavailable(self):
+        """vault_status is None when WikiClientUnavailableError is raised."""
+        from brain.device_ledger import DeviceLedger
+        from brain.voice_composer import VoiceComposer
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = str(Path(td) / "bi_wiki_unavail.db")
+            dl = DeviceLedger(db_path=db_file)
+            await dl.init()
+            vc = VoiceComposer(config={})
+
+            mock_wiki = MagicMock()
+            mock_wiki.status = AsyncMock(
+                side_effect=WikiClientUnavailableError("no connection")
+            )
+
+            fake_ws = _FakeWs()
+            mod._connected_clients.add(fake_ws)
+
+            try:
+                with (
+                    patch.object(mod, "_voice_composer", vc),
+                    patch.object(mod, "_device_ledger", dl),
+                    patch.object(mod, "_wiki_client", mock_wiki),
+                    patch.object(mod, "_last_wiki_search", None),
+                ):
+                    await mod.broadcast_brain_inspector()
+            finally:
+                mod._connected_clients.discard(fake_ws)
+
+        payload = json.loads(fake_ws.sent[0])["payload"]
+        assert payload["vault_status"] is None
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_vault_status_none_on_5s_timeout(self):
+        """vault_status is None when WikiClient.status() times out (5 s guard)."""
+        from brain.device_ledger import DeviceLedger
+        from brain.voice_composer import VoiceComposer
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = str(Path(td) / "bi_wiki_timeout.db")
+            dl = DeviceLedger(db_path=db_file)
+            await dl.init()
+            vc = VoiceComposer(config={})
+
+            mock_wiki = MagicMock()
+            # Simulate asyncio.wait_for raising TimeoutError for the status call.
+            mock_wiki.status = AsyncMock(side_effect=asyncio.TimeoutError)
+
+            fake_ws = _FakeWs()
+            mod._connected_clients.add(fake_ws)
+
+            try:
+                with (
+                    patch.object(mod, "_voice_composer", vc),
+                    patch.object(mod, "_device_ledger", dl),
+                    patch.object(mod, "_wiki_client", mock_wiki),
+                    patch.object(mod, "_last_wiki_search", None),
+                ):
+                    await mod.broadcast_brain_inspector()
+            finally:
+                mod._connected_clients.discard(fake_ws)
+
+        payload = json.loads(fake_ws.sent[0])["payload"]
+        assert payload["vault_status"] is None
+
+    @pytest.mark.asyncio
+    async def test_brain_inspector_last_wiki_search_reflected_in_payload(self):
+        """last_wiki_search state flows into broadcast_brain_inspector payload."""
+        from brain.device_ledger import DeviceLedger
+        from brain.voice_composer import VoiceComposer
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = str(Path(td) / "bi_last_search.db")
+            dl = DeviceLedger(db_path=db_file)
+            await dl.init()
+            vc = VoiceComposer(config={})
+
+            last_search = {"query": "Schwester", "hit_count": 2, "ts": "2025-01-15T10:00:00Z"}
+
+            fake_ws = _FakeWs()
+            mod._connected_clients.add(fake_ws)
+
+            try:
+                with (
+                    patch.object(mod, "_voice_composer", vc),
+                    patch.object(mod, "_device_ledger", dl),
+                    patch.object(mod, "_wiki_client", None),
+                    patch.object(mod, "_last_wiki_search", last_search),
+                ):
+                    await mod.broadcast_brain_inspector()
+            finally:
+                mod._connected_clients.discard(fake_ws)
+
+        payload = json.loads(fake_ws.sent[0])["payload"]
+        assert payload["last_wiki_search"] == last_search

--- a/tests/brain/test_intent_parser_wiki.py
+++ b/tests/brain/test_intent_parser_wiki.py
@@ -1,0 +1,277 @@
+"""Tests for the WIKI_LOOKUP intent in brain/intent_parser.py.
+
+Covers:
+- German trigger phrases ("was weißt du über X", variants)
+- English trigger phrases ("what do you know about X", variants)
+- Topic extraction (trigger stripped, only topic remains)
+- Non-matching queries do NOT classify as WIKI_LOOKUP
+- Confidence ≥ 0.80 on clear matches
+- Mixed-case and punctuation tolerance
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from brain.intent_parser import Intent, IntentParser
+
+
+@pytest.fixture
+def parser() -> IntentParser:
+    """Return a fresh IntentParser instance."""
+    return IntentParser()
+
+
+# ---------------------------------------------------------------------------
+# German trigger phrases
+# ---------------------------------------------------------------------------
+
+
+class TestWikiLookupGermanTriggers:
+    """German trigger phrases route to WIKI_LOOKUP with high confidence."""
+
+    @pytest.mark.asyncio
+    async def test_was_weisst_du_ueber_trigger(self, parser: IntentParser):
+        """'was weißt du über X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent("was weißt du über meine Schwester", language="de")
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_was_weist_du_ueber_no_umlaut_trigger(self, parser: IntentParser):
+        """'was weisst du über X' (no umlaut) → WIKI_LOOKUP via fallback pattern."""
+        result = await parser.classify_intent("was weiß du über meinen Bruder", language="de")
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_was_hast_du_ueber_trigger(self, parser: IntentParser):
+        """'was hast du über X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent("was hast du über das Meeting", language="de")
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_kennst_du_etwas_ueber_trigger(self, parser: IntentParser):
+        """'kennst du etwas über X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent("kennst du etwas über meine Schwester", language="de")
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_kennst_du_ueber_without_etwas(self, parser: IntentParser):
+        """'kennst du über X' (without etwas) → WIKI_LOOKUP."""
+        result = await parser.classify_intent("kennst du über das Projekt", language="de")
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_german_trigger_confidence_at_least_0_80(self, parser: IntentParser):
+        """German WIKI_LOOKUP matches must have confidence ≥ 0.80."""
+        result = await parser.classify_intent("was weißt du über meine Schwester", language="de")
+        assert result.confidence >= 0.80
+
+
+# ---------------------------------------------------------------------------
+# English trigger phrases
+# ---------------------------------------------------------------------------
+
+
+class TestWikiLookupEnglishTriggers:
+    """English trigger phrases route to WIKI_LOOKUP with high confidence."""
+
+    @pytest.mark.asyncio
+    async def test_what_do_you_know_about_trigger(self, parser: IntentParser):
+        """'what do you know about X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "what do you know about my sister", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_do_you_know_anything_about_trigger(self, parser: IntentParser):
+        """'do you know anything about X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "do you know anything about the project", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_do_you_know_something_about_trigger(self, parser: IntentParser):
+        """'do you know something about X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "do you know something about my brother", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_what_have_you_learned_about_trigger(self, parser: IntentParser):
+        """'what have you learned about X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "what have you learned about the deployment", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_tell_me_what_you_know_about_trigger(self, parser: IntentParser):
+        """'tell me what you know about X' → WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "tell me what you know about Alice", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_english_trigger_confidence_at_least_0_80(self, parser: IntentParser):
+        """English WIKI_LOOKUP matches must have confidence ≥ 0.80."""
+        result = await parser.classify_intent(
+            "what do you know about my sister", language="en"
+        )
+        assert result.confidence >= 0.80
+
+
+# ---------------------------------------------------------------------------
+# Topic extraction
+# ---------------------------------------------------------------------------
+
+
+class TestWikiLookupTopicExtraction:
+    """_extract_wiki_params strips trigger prefix, leaving only the topic."""
+
+    @pytest.mark.asyncio
+    async def test_german_topic_extracted_correctly(self, parser: IntentParser):
+        """'was weißt du über meine Schwester' → topic='meine schwester'."""
+        result = await parser.classify_intent("was weißt du über meine Schwester", language="de")
+        assert result.intent == Intent.WIKI_LOOKUP
+        topic = result.params.get("topic", "")
+        assert "schwester" in topic.lower()
+
+    @pytest.mark.asyncio
+    async def test_english_topic_extracted_correctly(self, parser: IntentParser):
+        """'what do you know about my sister' → topic='my sister'."""
+        result = await parser.classify_intent(
+            "what do you know about my sister", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+        topic = result.params.get("topic", "")
+        assert "sister" in topic.lower()
+
+    @pytest.mark.asyncio
+    async def test_topic_has_no_trigger_phrase_residue_german(self, parser: IntentParser):
+        """German: 'was weißt du über' is NOT part of the extracted topic."""
+        result = await parser.classify_intent("was weißt du über das Wetter", language="de")
+        topic = result.params.get("topic", "")
+        assert "was weißt du" not in topic.lower()
+        assert "weißt" not in topic.lower()
+
+    @pytest.mark.asyncio
+    async def test_topic_has_no_trigger_phrase_residue_english(self, parser: IntentParser):
+        """English: 'what do you know about' is NOT part of the extracted topic."""
+        result = await parser.classify_intent(
+            "what do you know about the weather", language="en"
+        )
+        topic = result.params.get("topic", "")
+        assert "what do you know" not in topic.lower()
+
+    @pytest.mark.asyncio
+    async def test_topic_stripped_of_trailing_punctuation(self, parser: IntentParser):
+        """Trailing '?' is stripped from the extracted topic."""
+        result = await parser.classify_intent(
+            "what do you know about my sister?", language="en"
+        )
+        topic = result.params.get("topic", "")
+        assert not topic.endswith("?")
+
+    @pytest.mark.asyncio
+    async def test_topic_params_key_present_on_match(self, parser: IntentParser):
+        """IntentResult.params always has a 'topic' key on WIKI_LOOKUP match."""
+        result = await parser.classify_intent(
+            "was weißt du über meine Schwester", language="de"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+        assert "topic" in result.params
+
+
+# ---------------------------------------------------------------------------
+# Non-matching queries
+# ---------------------------------------------------------------------------
+
+
+class TestWikiLookupNonMatches:
+    """Queries that should NOT classify as WIKI_LOOKUP."""
+
+    @pytest.mark.asyncio
+    async def test_calendar_query_not_wiki_lookup(self, parser: IntentParser):
+        """A calendar query does not become WIKI_LOOKUP."""
+        result = await parser.classify_intent("wie spät ist es?", language="de")
+        assert result.intent != Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_weather_query_not_wiki_lookup(self, parser: IntentParser):
+        """A weather question does not become WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "what's the weather like today?", language="en"
+        )
+        assert result.intent != Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_spotify_request_not_wiki_lookup(self, parser: IntentParser):
+        """A Spotify play request does not become WIKI_LOOKUP."""
+        result = await parser.classify_intent("play some music", language="en")
+        assert result.intent != Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_empty_text_not_wiki_lookup(self, parser: IntentParser):
+        """Empty input defaults to CHAT, not WIKI_LOOKUP."""
+        result = await parser.classify_intent("", language="en")
+        assert result.intent == Intent.CHAT
+
+    @pytest.mark.asyncio
+    async def test_generic_question_not_wiki_lookup_german(self, parser: IntentParser):
+        """A generic German question does not trigger WIKI_LOOKUP."""
+        result = await parser.classify_intent("was ist das?", language="de")
+        assert result.intent != Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_partial_trigger_not_wiki_lookup(self, parser: IntentParser):
+        """A partial trigger phrase without topic does not match WIKI_LOOKUP."""
+        # "know about" alone, without full phrase, should not match
+        result = await parser.classify_intent("do you know this?", language="en")
+        assert result.intent != Intent.WIKI_LOOKUP
+
+
+# ---------------------------------------------------------------------------
+# Mixed-case and punctuation tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestWikiLookupCaseAndPunctuation:
+    """WIKI_LOOKUP matching tolerates case differences and punctuation."""
+
+    @pytest.mark.asyncio
+    async def test_uppercase_trigger_still_matches(self, parser: IntentParser):
+        """Uppercase variant still classifies as WIKI_LOOKUP (re.IGNORECASE)."""
+        result = await parser.classify_intent(
+            "WHAT DO YOU KNOW ABOUT my sister", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_mixed_case_trigger_still_matches(self, parser: IntentParser):
+        """Mixed-case variant still classifies as WIKI_LOOKUP."""
+        result = await parser.classify_intent(
+            "What Do You Know About my sister", language="en"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_trailing_question_mark_does_not_prevent_match(self, parser: IntentParser):
+        """Trailing '?' does not prevent matching."""
+        result = await parser.classify_intent(
+            "was weißt du über meine Schwester?", language="de"
+        )
+        assert result.intent == Intent.WIKI_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_topic_contains_actual_subject(self, parser: IntentParser):
+        """Extracted topic from 'what do you know about my sister' contains 'sister'."""
+        result = await parser.classify_intent(
+            "what do you know about my sister", language="en"
+        )
+        topic = result.params.get("topic", "")
+        assert len(topic) > 0
+        assert "my sister" in topic or "sister" in topic

--- a/tests/brain/test_orchestrator_wiki.py
+++ b/tests/brain/test_orchestrator_wiki.py
@@ -1,0 +1,508 @@
+"""Tests for _handle_wiki_lookup() in brain/orchestrator.py — AC #11.
+
+Covers:
+- Hit path: high-score hit → templated narration mentioning title; no agent RPC.
+- No-hits path: empty search → returns None → falls through to slow-path.
+- Below-threshold path: low-score hit → returns None.
+- WikiClientUnavailableError → returns None cleanly.
+- fast_path_enabled=false in config → returns None immediately, no search call.
+- German and English narration templates produce sensible output.
+- AC #11: end-to-end fast-path bypasses any agent/OpenClaw RPC.
+
+All external I/O (OpenClaw, config, DB) is mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from brain.intent_parser import Intent, IntentResult
+from integrations.openclaw.wiki_client import WikiClientUnavailableError, WikiHit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hit(
+    note_id: str = "notes/sister",
+    title: str = "Schwester",
+    score: float = 0.92,
+    excerpt: str = "Geburtstag am 12. Juni.",
+    updated_at: str = "2025-01-15T10:00:00Z",
+) -> WikiHit:
+    return WikiHit(
+        id=note_id,
+        title=title,
+        score=score,
+        excerpt=excerpt,
+        updated_at=updated_at,
+    )
+
+
+def _make_intent_result(topic: str = "meine Schwester", language: str = "de") -> IntentResult:
+    return IntentResult(
+        intent=Intent.WIKI_LOOKUP,
+        confidence=0.90,
+        params={"topic": topic},
+        original_text=f"was weißt du über {topic}",
+        language=language,
+    )
+
+
+def _make_cfg_mock(
+    fast_path_enabled: bool = True,
+    fast_path_min_score: float = 0.75,
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.get_section.side_effect = lambda section: {
+        "agents": {
+            "orchestrator_model": "claude-opus-4-5",
+            "orchestrator_max_tokens": 150,
+            "skip_orchestrator_on_clear_intent": True,
+            "history_turns_for_orchestrator": 3,
+        },
+        "vault": {
+            "fast_path_enabled": fast_path_enabled,
+            "fast_path_min_score": fast_path_min_score,
+        },
+    }.get(section, {})
+    cfg.get.return_value = "Europe/Zurich"
+    return cfg
+
+
+def _make_orchestrator(cfg_mock, wiki_client=None) -> "Orchestrator":
+    from brain.orchestrator import Orchestrator
+
+    mock_claude = MagicMock()
+    mock_claude.chat = AsyncMock(
+        side_effect=AssertionError("ClaudeClient.chat must NOT be called in fast-path test")
+    )
+    mock_claude.openclaw = None
+
+    with patch("brain.orchestrator.get_config", return_value=cfg_mock):
+        orch = Orchestrator(claude_client=mock_claude, wiki_client=wiki_client)
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# _handle_wiki_lookup — hit path (AC #11)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWikiLookupHitPath:
+    """Fast-path hit: returns narration, no OpenClaw/agent call."""
+
+    @pytest.mark.asyncio
+    async def test_hit_above_threshold_returns_agent_result(self):
+        """Single hit above min_score returns AgentResult with non-empty text."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[_make_hit(score=0.92)])
+
+        cfg = _make_cfg_mock(fast_path_enabled=True, fast_path_min_score=0.75)
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        intent_result = _make_intent_result(topic="meine Schwester", language="de")
+        result = await orch._handle_wiki_lookup(intent_result, language="de")
+
+        assert result is not None
+        assert result.success is True
+        assert len(result.spoken_response) > 0
+
+    @pytest.mark.asyncio
+    async def test_hit_narration_mentions_top_title_german(self):
+        """German narration mentions the top hit's title."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(
+            return_value=[_make_hit(title="Schwester", score=0.92, excerpt="Geburtstag")]
+        )
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="meine Schwester", language="de"), language="de"
+        )
+
+        assert result is not None
+        assert "Schwester" in result.spoken_response
+
+    @pytest.mark.asyncio
+    async def test_hit_narration_mentions_top_title_english(self):
+        """English narration mentions the top hit's title."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(
+            return_value=[_make_hit(title="Sister", score=0.90, excerpt="Birthday")]
+        )
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="my sister", language="en"), language="en"
+        )
+
+        assert result is not None
+        assert "Sister" in result.spoken_response
+
+    @pytest.mark.asyncio
+    async def test_agent_rpc_not_called_on_fast_path_hit(self):
+        """AC #11: no agent RPC is issued when fast-path returns a result."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[_make_hit(score=0.90)])
+
+        cfg = _make_cfg_mock()
+        mock_claude = MagicMock()
+        agent_call_count = 0
+
+        async def _forbidden_chat(*_a, **_kw):
+            nonlocal agent_call_count
+            agent_call_count += 1
+            return "should not be called"
+
+        mock_claude.chat = _forbidden_chat
+        mock_claude.openclaw = None
+
+        with patch("brain.orchestrator.get_config", return_value=cfg):
+            from brain.orchestrator import Orchestrator
+            orch = Orchestrator(claude_client=mock_claude, wiki_client=mock_wiki)
+
+        intent_result = _make_intent_result(topic="meine Schwester", language="de")
+        result = await orch._handle_wiki_lookup(intent_result, language="de")
+
+        assert result is not None
+        assert agent_call_count == 0, "ClaudeClient.chat must NOT be called for fast-path hit"
+
+    @pytest.mark.asyncio
+    async def test_multiple_hits_all_appear_in_narration(self):
+        """When ≥2 hits qualify, narration lists multiple titles."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(
+            return_value=[
+                _make_hit(note_id="n1", title="Schwester", score=0.95),
+                _make_hit(note_id="n2", title="Familie", score=0.88),
+            ]
+        )
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="Familie", language="de"), language="de"
+        )
+
+        assert result is not None
+        # At least one of the titles must appear.
+        assert "Schwester" in result.spoken_response or "Familie" in result.spoken_response
+
+    @pytest.mark.asyncio
+    async def test_narration_not_raw_dataclass_repr(self):
+        """Spoken response does not contain raw WikiHit dataclass repr."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[_make_hit(score=0.90)])
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="Schwester", language="de"), language="de"
+        )
+
+        assert result is not None
+        assert "WikiHit(" not in result.spoken_response
+
+
+# ---------------------------------------------------------------------------
+# _handle_wiki_lookup — no-hits path
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWikiLookupNoHits:
+    """Empty search result falls through to slow-path."""
+
+    @pytest.mark.asyncio
+    async def test_no_hits_returns_none(self):
+        """search() returns [] → _handle_wiki_lookup returns None."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[])
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="unbekanntes Thema", language="de"), language="de"
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_hits_slow_path_called_via_process(self):
+        """When fast-path returns None, process() calls the slow-path chat agent."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[])
+
+        chat_was_called = []
+
+        mock_claude = MagicMock()
+
+        async def _fake_chat(*_a, **_kw):
+            chat_was_called.append(True)
+            return "OpenClaw slow-path response"
+
+        mock_claude.chat = _fake_chat
+        mock_claude.openclaw = None
+
+        cfg = _make_cfg_mock()
+        with patch("brain.orchestrator.get_config", return_value=cfg):
+            from brain.orchestrator import Orchestrator
+            orch = Orchestrator(claude_client=mock_claude, wiki_client=mock_wiki)
+
+        intent_result = _make_intent_result(topic="unbekanntes Thema", language="de")
+        intent_result.confidence = 0.90  # above threshold
+
+        result = await orch.process(
+            "was weißt du über unbekanntes Thema",
+            language="de",
+            intent_result=intent_result,
+        )
+
+        # Slow-path (chat) should have been called.
+        assert chat_was_called, "Slow-path chat.run() was not called after fast-path miss"
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _handle_wiki_lookup — below threshold
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWikiLookupBelowThreshold:
+    """Hits below min_score fall through."""
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_score_returns_none(self):
+        """Hit with score below fast_path_min_score → None."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[_make_hit(score=0.50)])
+
+        cfg = _make_cfg_mock(fast_path_min_score=0.75)
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="topic", language="en"), language="en"
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_threshold_qualifies(self):
+        """Hit with score exactly equal to fast_path_min_score qualifies."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[_make_hit(score=0.75)])
+
+        cfg = _make_cfg_mock(fast_path_min_score=0.75)
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="topic", language="en"), language="en"
+        )
+
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _handle_wiki_lookup — WikiClientUnavailableError
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWikiLookupUnavailable:
+    """WikiClientUnavailableError falls through cleanly."""
+
+    @pytest.mark.asyncio
+    async def test_wiki_unavailable_returns_none_no_exception(self):
+        """WikiClientUnavailableError from search → returns None, no exception bubbles."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(
+            side_effect=WikiClientUnavailableError("connection lost")
+        )
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        # Must not raise.
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="Schwester", language="de"), language="de"
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none_no_exception(self):
+        """asyncio.TimeoutError from search → returns None, no exception bubbles."""
+        import asyncio
+
+        mock_wiki = MagicMock()
+
+        async def _slow_search(*_a, **_kw):
+            await asyncio.sleep(9999)
+
+        mock_wiki.search = _slow_search
+
+        cfg = _make_cfg_mock()
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        with patch("brain.orchestrator.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            result = await orch._handle_wiki_lookup(
+                _make_intent_result(topic="Schwester", language="de"), language="de"
+            )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_wiki_lookup — fast_path_enabled=False
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWikiLookupDisabled:
+    """fast_path_enabled=False disables the fast-path entirely."""
+
+    @pytest.mark.asyncio
+    async def test_fast_path_disabled_returns_none_immediately(self):
+        """fast_path_enabled=false → None without calling WikiClient.search."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(return_value=[_make_hit(score=0.99)])
+
+        cfg = _make_cfg_mock(fast_path_enabled=False)
+        orch = _make_orchestrator(cfg, wiki_client=mock_wiki)
+
+        # _handle_wiki_lookup calls get_config() at call time, so patch it there too.
+        with patch("brain.orchestrator.get_config", return_value=cfg):
+            result = await orch._handle_wiki_lookup(
+                _make_intent_result(topic="Schwester", language="de"), language="de"
+            )
+
+        assert result is None
+        mock_wiki.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fast_path_disabled_wiki_client_none_still_none(self):
+        """Returns None also when wiki_client is None and fast_path is disabled."""
+        cfg = _make_cfg_mock(fast_path_enabled=False)
+        orch = _make_orchestrator(cfg, wiki_client=None)
+
+        with patch("brain.orchestrator.get_config", return_value=cfg):
+            result = await orch._handle_wiki_lookup(
+                _make_intent_result(topic="Schwester", language="de"), language="de"
+            )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_wiki_lookup — wiki_client is None
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWikiLookupNoClient:
+    """No WikiClient attached → falls through."""
+
+    @pytest.mark.asyncio
+    async def test_no_wiki_client_returns_none(self):
+        """When wiki_client=None and fast_path_enabled, returns None."""
+        cfg = _make_cfg_mock(fast_path_enabled=True)
+        orch = _make_orchestrator(cfg, wiki_client=None)
+
+        result = await orch._handle_wiki_lookup(
+            _make_intent_result(topic="Schwester", language="de"), language="de"
+        )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Full process() integration path — AC #11 end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorWikiLookupProcessIntegration:
+    """process() dispatches WIKI_LOOKUP and fast-path bypasses OpenClaw."""
+
+    @pytest.mark.asyncio
+    async def test_process_wiki_lookup_fast_path_does_not_call_openclaw(self):
+        """AC #11: process() with WIKI_LOOKUP high-confidence returns fast-path result."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(
+            return_value=[_make_hit(title="Schwester", score=0.92)]
+        )
+
+        chat_called = []
+        mock_claude = MagicMock()
+
+        async def _forbidden_chat(*_a, **_kw):
+            chat_called.append(True)
+            return "should not be called"
+
+        mock_claude.chat = _forbidden_chat
+        mock_claude.openclaw = None
+
+        cfg = _make_cfg_mock()
+        with patch("brain.orchestrator.get_config", return_value=cfg):
+            from brain.orchestrator import Orchestrator
+            orch = Orchestrator(claude_client=mock_claude, wiki_client=mock_wiki)
+
+        intent_result = IntentResult(
+            intent=Intent.WIKI_LOOKUP,
+            confidence=0.90,
+            params={"topic": "meine Schwester"},
+            original_text="was weißt du über meine Schwester",
+            language="de",
+        )
+
+        result = await orch.process(
+            "was weißt du über meine Schwester",
+            language="de",
+            intent_result=intent_result,
+        )
+
+        assert result is not None
+        assert result.success is True
+        assert "Schwester" in result.spoken_response
+        assert not chat_called, "OpenClaw/chat was called — fast-path should have handled it"
+
+    @pytest.mark.asyncio
+    async def test_process_wiki_lookup_english_fast_path(self):
+        """process() English WIKI_LOOKUP also returns fast-path result."""
+        mock_wiki = MagicMock()
+        mock_wiki.search = AsyncMock(
+            return_value=[_make_hit(title="Sister Note", score=0.88)]
+        )
+
+        mock_claude = MagicMock()
+        mock_claude.chat = AsyncMock(return_value="should not be called")
+        mock_claude.openclaw = None
+
+        cfg = _make_cfg_mock()
+        with patch("brain.orchestrator.get_config", return_value=cfg):
+            from brain.orchestrator import Orchestrator
+            orch = Orchestrator(claude_client=mock_claude, wiki_client=mock_wiki)
+
+        intent_result = IntentResult(
+            intent=Intent.WIKI_LOOKUP,
+            confidence=0.85,
+            params={"topic": "my sister"},
+            original_text="what do you know about my sister",
+            language="en",
+        )
+
+        result = await orch.process(
+            "what do you know about my sister",
+            language="en",
+            intent_result=intent_result,
+        )
+
+        assert result is not None
+        assert "Sister Note" in result.spoken_response

--- a/tests/integrations/openclaw/test_wiki_client.py
+++ b/tests/integrations/openclaw/test_wiki_client.py
@@ -1,0 +1,460 @@
+"""Tests for WikiClient — async read-only bridge to OpenClaw's memory-wiki RPC.
+
+Covers every public method (search, get, status, obsidian_open) plus error
+mapping (_RPC_TIMEOUT_S, bad response shapes, generic exceptions).  All
+external I/O is mocked; no live OpenClaw gateway is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from integrations.openclaw.wiki_client import (
+    WikiClient,
+    WikiClientUnavailableError,
+    WikiHit,
+    WikiNote,
+    WikiStatus,
+    _RPC_TIMEOUT_S,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_client(is_connected: bool = True) -> MagicMock:
+    """Return a stub OpenClawWSClient with a call_rpc AsyncMock."""
+    ws = MagicMock()
+    ws.is_connected = is_connected
+    ws.connect = AsyncMock()
+    ws.call_rpc = AsyncMock()
+    return ws
+
+
+def _make_client(is_connected: bool = True) -> tuple[WikiClient, MagicMock]:
+    """Return (WikiClient, stub_ws_client) pair."""
+    ws = _make_ws_client(is_connected=is_connected)
+    client = WikiClient(ws)
+    return client, ws
+
+
+# Typical OpenClaw wiki.search response payload.
+_SAMPLE_SEARCH_PAYLOAD = [
+    {
+        "id": "notes/sister",
+        "path": "notes/sister",
+        "title": "Schwester",
+        "score": 0.92,
+        "snippet": "Geburtstag am 12. Juni.",
+        "updatedAt": "2025-01-15T10:00:00Z",
+    },
+    {
+        "id": "notes/family",
+        "path": "notes/family",
+        "title": "Familie",
+        "score": 0.80,
+        "snippet": "Familie details.",
+        "updatedAt": "2025-01-10T08:00:00Z",
+    },
+]
+
+# Typical OpenClaw wiki.get response payload.
+_SAMPLE_NOTE_PAYLOAD = {
+    "id": "notes/sister",
+    "path": "notes/sister",
+    "title": "Schwester",
+    "content": "# Schwester\n\nGeburtstag am 12. Juni.",
+    "updatedAt": "2025-01-15T10:00:00Z",
+}
+
+# Typical wiki.status payload.
+_SAMPLE_STATUS_PAYLOAD = {
+    "vaultExists": True,
+    "vaultPath": "/home/user/Obsidian/jarvis-vault",
+    "renderMode": "obsidian",
+    "pageCounts": {"notes": 42, "journal": 8},
+}
+
+
+# ---------------------------------------------------------------------------
+# WikiClient.search
+# ---------------------------------------------------------------------------
+
+
+class TestWikiClientSearch:
+    """Tests for WikiClient.search()."""
+
+    @pytest.mark.asyncio
+    async def test_search_happy_path_returns_wiki_hits(self):
+        """search() maps RPC list response to list[WikiHit]."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=_SAMPLE_SEARCH_PAYLOAD)
+
+        hits = await client.search("Schwester", k=6)
+
+        assert len(hits) == 2
+        assert all(isinstance(h, WikiHit) for h in hits)
+        assert hits[0].id == "notes/sister"
+        assert hits[0].title == "Schwester"
+        assert hits[0].score == 0.92
+        assert hits[0].excerpt == "Geburtstag am 12. Juni."
+        assert hits[0].updated_at == "2025-01-15T10:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_search_forwards_k_parameter(self):
+        """search() passes maxResults=k in the RPC params dict."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=[])
+
+        await client.search("test", k=3)
+
+        ws.call_rpc.assert_awaited_once()
+        _, params = ws.call_rpc.call_args[0]
+        assert params["maxResults"] == 3
+
+    @pytest.mark.asyncio
+    async def test_search_empty_vault_returns_empty_list(self):
+        """search() returns [] when RPC returns empty list."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=[])
+
+        hits = await client.search("nothing here")
+
+        assert hits == []
+
+    @pytest.mark.asyncio
+    async def test_search_timeout_raises_unavailable_error(self):
+        """asyncio.TimeoutError from call_rpc → WikiClientUnavailableError with method name."""
+        client, ws = _make_client()
+
+        async def _slow_rpc(*_a, **_kw):
+            await asyncio.sleep(9999)
+
+        ws.call_rpc = _slow_rpc
+
+        with patch(
+            "integrations.openclaw.wiki_client.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ):
+            with pytest.raises(WikiClientUnavailableError) as exc_info:
+                await client.search("test")
+
+        assert "wiki.search" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_generic_exception_raises_unavailable_error(self):
+        """Generic Exception from call_rpc → WikiClientUnavailableError."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(side_effect=RuntimeError("connection reset"))
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.search("test")
+
+        assert "wiki.search" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_search_non_list_result_returns_empty_list(self):
+        """If RPC returns a non-list (e.g. dict), search() yields []."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value={"error": "unexpected"})
+
+        hits = await client.search("test")
+
+        assert hits == []
+
+    @pytest.mark.asyncio
+    async def test_search_rpc_timeout_constant_honored(self):
+        """_RPC_TIMEOUT_S is passed to asyncio.wait_for as timeout."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=[])
+
+        timeouts_seen: list[float] = []
+        _orig_wait_for = asyncio.wait_for
+
+        async def _capturing_wait_for(coro, timeout=None, **kw):
+            timeouts_seen.append(timeout)
+            return await _orig_wait_for(coro, timeout=timeout, **kw)
+
+        with patch(
+            "integrations.openclaw.wiki_client.asyncio.wait_for",
+            side_effect=_capturing_wait_for,
+        ):
+            await client.search("test")
+
+        assert timeouts_seen and timeouts_seen[0] == _RPC_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# WikiClient.get
+# ---------------------------------------------------------------------------
+
+
+class TestWikiClientGet:
+    """Tests for WikiClient.get()."""
+
+    @pytest.mark.asyncio
+    async def test_get_happy_path_returns_wiki_note(self):
+        """get() maps RPC dict response to WikiNote with body_md from 'content'."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=_SAMPLE_NOTE_PAYLOAD)
+
+        note = await client.get("notes/sister")
+
+        assert isinstance(note, WikiNote)
+        assert note.id == "notes/sister"
+        assert note.title == "Schwester"
+        assert "Geburtstag" in note.body_md
+        assert note.updated_at == "2025-01-15T10:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_get_uses_content_field_as_body_md(self):
+        """get() maps the 'content' RPC field to WikiNote.body_md."""
+        client, ws = _make_client()
+        payload = {
+            "id": "my-note",
+            "title": "My Note",
+            "content": "# Heading\n\nBody text here.",
+            "updatedAt": "2025-02-01T00:00:00Z",
+        }
+        ws.call_rpc = AsyncMock(return_value=payload)
+
+        note = await client.get("my-note")
+
+        assert note.body_md == "# Heading\n\nBody text here."
+
+    @pytest.mark.asyncio
+    async def test_get_falls_back_to_path_for_id(self):
+        """get() uses 'path' as note id when 'id' is absent from response."""
+        client, ws = _make_client()
+        payload = {
+            "path": "notes/fallback",
+            "title": "Fallback",
+            "content": "content",
+            "updatedAt": "",
+        }
+        ws.call_rpc = AsyncMock(return_value=payload)
+
+        note = await client.get("notes/fallback")
+
+        assert note.id == "notes/fallback"
+
+    @pytest.mark.asyncio
+    async def test_get_non_dict_result_raises_unavailable_error(self):
+        """get() raises WikiClientUnavailableError when RPC returns a non-dict."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value="this is a string")
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.get("some-note")
+
+        assert "str" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_timeout_raises_unavailable_error(self):
+        """asyncio.TimeoutError from call_rpc → WikiClientUnavailableError with method name."""
+        client, ws = _make_client()
+
+        with patch(
+            "integrations.openclaw.wiki_client.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ):
+            with pytest.raises(WikiClientUnavailableError) as exc_info:
+                await client.get("test")
+
+        assert "wiki.get" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_generic_exception_raises_unavailable_error(self):
+        """Generic Exception from call_rpc → WikiClientUnavailableError."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(side_effect=ConnectionError("dropped"))
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.get("test")
+
+        assert "wiki.get" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# WikiClient.status
+# ---------------------------------------------------------------------------
+
+
+class TestWikiClientStatus:
+    """Tests for WikiClient.status()."""
+
+    @pytest.mark.asyncio
+    async def test_status_happy_path_returns_wiki_status(self):
+        """status() maps RPC dict to WikiStatus, summing pageCounts."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=_SAMPLE_STATUS_PAYLOAD)
+
+        st = await client.status()
+
+        assert isinstance(st, WikiStatus)
+        assert st.initialised is True
+        assert st.note_count == 50  # 42 + 8
+        assert st.path == "/home/user/Obsidian/jarvis-vault"
+        assert st.render_mode == "obsidian"
+        assert st.last_dream_cycle_at is None
+
+    @pytest.mark.asyncio
+    async def test_status_vault_not_exists_returns_uninitialised(self):
+        """status() sets initialised=False when vaultExists is False."""
+        client, ws = _make_client()
+        payload = {
+            "vaultExists": False,
+            "vaultPath": "",
+            "renderMode": "",
+            "pageCounts": {},
+        }
+        ws.call_rpc = AsyncMock(return_value=payload)
+
+        st = await client.status()
+
+        assert st.initialised is False
+        assert st.note_count == 0
+
+    @pytest.mark.asyncio
+    async def test_status_sums_all_page_count_categories(self):
+        """status() sums all values in pageCounts regardless of category names."""
+        client, ws = _make_client()
+        payload = {
+            "vaultExists": True,
+            "vaultPath": "/vault",
+            "renderMode": "obsidian",
+            "pageCounts": {"notes": 10, "journal": 5, "attachments": 3, "index": 2},
+        }
+        ws.call_rpc = AsyncMock(return_value=payload)
+
+        st = await client.status()
+
+        assert st.note_count == 20
+
+    @pytest.mark.asyncio
+    async def test_status_non_dict_result_raises_unavailable_error(self):
+        """status() raises WikiClientUnavailableError when RPC returns non-dict."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value=["unexpected", "list"])
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.status()
+
+        assert "list" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_status_timeout_raises_unavailable_error(self):
+        """asyncio.TimeoutError from call_rpc → WikiClientUnavailableError."""
+        client, ws = _make_client()
+
+        with patch(
+            "integrations.openclaw.wiki_client.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ):
+            with pytest.raises(WikiClientUnavailableError) as exc_info:
+                await client.status()
+
+        assert "wiki.status" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_status_generic_exception_raises_unavailable_error(self):
+        """Generic Exception → WikiClientUnavailableError with method name in message."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(side_effect=OSError("socket error"))
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.status()
+
+        assert "wiki.status" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# WikiClient.obsidian_open
+# ---------------------------------------------------------------------------
+
+
+class TestWikiClientObsidianOpen:
+    """Tests for WikiClient.obsidian_open()."""
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_returns_true_on_success(self):
+        """obsidian_open() returns True when the RPC call succeeds."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(return_value={"ok": True})
+
+        result = await client.obsidian_open("notes/sister")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_timeout_raises_unavailable_error(self):
+        """asyncio.TimeoutError → WikiClientUnavailableError with method name."""
+        client, ws = _make_client()
+
+        with patch(
+            "integrations.openclaw.wiki_client.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ):
+            with pytest.raises(WikiClientUnavailableError) as exc_info:
+                await client.obsidian_open("test")
+
+        assert "wiki.obsidian.open" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_obsidian_open_generic_exception_raises_unavailable_error(self):
+        """Generic Exception → WikiClientUnavailableError."""
+        client, ws = _make_client()
+        ws.call_rpc = AsyncMock(side_effect=RuntimeError("Obsidian not running"))
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.obsidian_open("some/note")
+
+        assert "wiki.obsidian.open" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# WikiClient._call — connection handling
+# ---------------------------------------------------------------------------
+
+
+class TestWikiClientCallConnectionHandling:
+    """Tests for _call connection auto-connect behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_call_auto_connects_when_not_connected(self):
+        """_call() calls ws_client.connect() when is_connected is False."""
+        client, ws = _make_client(is_connected=False)
+        ws.connect = AsyncMock()
+        ws.call_rpc = AsyncMock(return_value=[])
+
+        await client.search("test")
+
+        ws.connect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_call_skips_connect_when_already_connected(self):
+        """_call() does not call connect() when is_connected is already True."""
+        client, ws = _make_client(is_connected=True)
+        ws.connect = AsyncMock()
+        ws.call_rpc = AsyncMock(return_value=[])
+
+        await client.search("test")
+
+        ws.connect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_call_connect_failure_raises_unavailable_error(self):
+        """If connect() raises, _call() raises WikiClientUnavailableError."""
+        client, ws = _make_client(is_connected=False)
+        ws.connect = AsyncMock(side_effect=ConnectionRefusedError("refused"))
+
+        with pytest.raises(WikiClientUnavailableError) as exc_info:
+            await client.search("test")
+
+        assert "Cannot connect" in str(exc_info.value)

--- a/tests/utils/test_config_loader_vault.py
+++ b/tests/utils/test_config_loader_vault.py
@@ -1,0 +1,239 @@
+"""Tests for vault.path expansion + env override in src/utils/config_loader.py.
+
+Covers:
+- vault.path with leading '~' is expanded to absolute home path on load.
+- JARVIS_VAULT_PATH env-var overrides YAML value AND is '~'-expanded.
+- Empty/missing vault block does not crash; vault.enabled defaults sensibly.
+- JARVIS_VAULT_PATH with a plain absolute path (no '~') is preserved as-is.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_loader(config_dict: dict[str, Any]) -> "ConfigLoader":
+    """Return a ConfigLoader whose _config was built from config_dict.
+
+    Bypasses file I/O by monkeypatching _load() to directly populate
+    the private _config, then calling _apply_env_overrides() explicitly
+    so env-var logic runs.
+    """
+    from utils.config_loader import ConfigLoader
+
+    # Reset the singleton so each test gets a fresh instance.
+    ConfigLoader._instance = None
+    ConfigLoader._config = {}
+
+    loader = ConfigLoader.__new__(ConfigLoader)
+    loader._config = dict(config_dict)
+    loader._apply_env_overrides()
+    return loader
+
+
+# ---------------------------------------------------------------------------
+# vault.path ~ expansion from YAML
+# ---------------------------------------------------------------------------
+
+
+class TestVaultPathTildeExpansion:
+    """vault.path with leading '~' expands to an absolute path on load."""
+
+    def test_tilde_in_yaml_vault_path_is_expanded(self):
+        """ConfigLoader expands '~/Obsidian/jarvis-vault' to an absolute path."""
+        raw_config = {
+            "vault": {
+                "enabled": True,
+                "path": "~/Obsidian/jarvis-vault",
+            }
+        }
+
+        # Ensure JARVIS_VAULT_PATH env var is NOT set.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader(raw_config)
+
+        vault_path = loader.get_section("vault").get("path", "")
+        assert vault_path != "~/Obsidian/jarvis-vault", "~ should have been expanded"
+        assert os.path.isabs(vault_path), f"Path should be absolute: {vault_path!r}"
+        assert "Obsidian" in vault_path or "jarvis-vault" in vault_path
+
+    def test_absolute_path_in_yaml_unchanged(self):
+        """An already-absolute path in YAML is left unchanged."""
+        raw_config = {
+            "vault": {
+                "enabled": True,
+                "path": "/srv/jarvis-vault",
+            }
+        }
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader(raw_config)
+
+        vault_path = loader.get_section("vault").get("path", "")
+        assert vault_path == "/srv/jarvis-vault"
+
+    def test_empty_path_does_not_crash(self):
+        """An empty vault.path in YAML does not raise any exception."""
+        raw_config = {
+            "vault": {
+                "enabled": True,
+                "path": "",
+            }
+        }
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader(raw_config)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# JARVIS_VAULT_PATH env-var override
+# ---------------------------------------------------------------------------
+
+
+class TestVaultPathEnvOverride:
+    """JARVIS_VAULT_PATH env-var overrides the YAML value."""
+
+    def test_env_var_overrides_yaml_value(self):
+        """JARVIS_VAULT_PATH=/tmp/test-vault overrides YAML vault.path."""
+        raw_config = {
+            "vault": {
+                "enabled": True,
+                "path": "~/Obsidian/jarvis-vault",
+            }
+        }
+
+        with patch.dict(os.environ, {"JARVIS_VAULT_PATH": "/tmp/test-vault"}, clear=False):
+            loader = _fresh_loader(raw_config)
+
+        vault_path = loader.get_section("vault").get("path", "")
+        assert vault_path == "/tmp/test-vault"
+
+    def test_env_var_with_tilde_is_expanded(self):
+        """JARVIS_VAULT_PATH=~/custom-vault → ~ is also expanded."""
+        raw_config = {
+            "vault": {
+                "enabled": True,
+                "path": "~/Obsidian/jarvis-vault",
+            }
+        }
+
+        with patch.dict(os.environ, {"JARVIS_VAULT_PATH": "~/custom-vault"}, clear=False):
+            loader = _fresh_loader(raw_config)
+
+        vault_path = loader.get_section("vault").get("path", "")
+        assert not vault_path.startswith("~"), f"~ was not expanded: {vault_path!r}"
+        assert os.path.isabs(vault_path), f"Path should be absolute: {vault_path!r}"
+        assert "custom-vault" in vault_path
+
+    def test_env_var_overrides_even_when_no_vault_yaml_block(self):
+        """JARVIS_VAULT_PATH creates vault section even if YAML had none."""
+        raw_config: dict[str, Any] = {}  # no vault block at all
+
+        with patch.dict(os.environ, {"JARVIS_VAULT_PATH": "/tmp/test-vault"}, clear=False):
+            loader = _fresh_loader(raw_config)
+
+        vault_path = loader.get_section("vault").get("path", "")
+        assert vault_path == "/tmp/test-vault"
+
+    def test_env_var_absolute_path_preserved_without_expansion(self):
+        """An absolute JARVIS_VAULT_PATH (no ~) is stored as-is."""
+        raw_config: dict[str, Any] = {"vault": {"path": "~/default"}}
+
+        with patch.dict(os.environ, {"JARVIS_VAULT_PATH": "/absolute/path"}, clear=False):
+            loader = _fresh_loader(raw_config)
+
+        vault_path = loader.get_section("vault").get("path", "")
+        assert vault_path == "/absolute/path"
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing vault block
+# ---------------------------------------------------------------------------
+
+
+class TestVaultBlockAbsent:
+    """Missing or empty vault block does not crash and defaults are sensible."""
+
+    def test_no_vault_block_does_not_crash(self):
+        """ConfigLoader with no vault block at all does not raise."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader({})  # must not raise
+
+        # vault section should be empty or missing, not an error.
+        vault = loader.get_section("vault")
+        assert isinstance(vault, dict)
+
+    def test_vault_enabled_defaults_sensibly_when_absent(self):
+        """When vault block is absent, enabled check with default=False returns False."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader({})
+
+        # Caller uses vault_cfg.get("enabled", False) → should be falsy.
+        vault_cfg = loader.get_section("vault") or {}
+        assert not vault_cfg.get("enabled", False)
+
+    def test_empty_vault_block_does_not_crash(self):
+        """An empty vault dict in YAML does not raise."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader({"vault": {}})  # must not raise
+
+    def test_vault_block_with_only_enabled_flag_does_not_crash(self):
+        """vault: {enabled: true} with no path does not raise."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader({"vault": {"enabled": True}})  # must not raise
+
+        vault_cfg = loader.get_section("vault")
+        assert vault_cfg.get("enabled") is True
+
+
+# ---------------------------------------------------------------------------
+# ConfigLoader.get() dot-notation for vault keys
+# ---------------------------------------------------------------------------
+
+
+class TestVaultConfigGet:
+    """ConfigLoader.get() with dot-notation reaches vault sub-keys."""
+
+    def test_get_vault_path_via_dot_notation(self):
+        """get('vault.path') returns the expanded vault path."""
+        raw_config = {
+            "vault": {
+                "path": "~/Obsidian/jarvis-vault",
+                "enabled": True,
+            }
+        }
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader(raw_config)
+
+        path_via_dot = loader.get("vault.path", "")
+        assert path_via_dot != "~/Obsidian/jarvis-vault"
+        assert os.path.isabs(path_via_dot)
+
+    def test_get_vault_enabled_via_dot_notation(self):
+        """get('vault.enabled') returns the enabled flag."""
+        raw_config = {"vault": {"enabled": True, "path": "/some/path"}}
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_VAULT_PATH", None)
+            loader = _fresh_loader(raw_config)
+
+        assert loader.get("vault.enabled") is True


### PR DESCRIPTION
## Summary

- Wires JARVIS to OpenClaw's `memory-wiki` plugin via a read-only `WikiClient` bridge — search/get/status/obsidian-open over the existing `OpenClawWSClient` connection (extended with a new `call_rpc` request/response method).
- Voice fast-path intent `WIKI_LOOKUP` ("was weißt du über X" / "what do you know about X") answers from the vault without an LLM agent round-trip.
- Vault-init script (`scripts/init_jarvis_vault.sh`), `vault:` config block with `~`-expansion + `JARVIS_VAULT_PATH` env-var override, `brain_inspector` payload extension (`vault_status` + `last_wiki_search`), 3 REST endpoints (`/api/brain/wiki/search|note/{id}|obsidian-open`).
- `_brain_inspector_loop` now broadcasts immediately on startup before entering the sleep cycle — fixes ledger-inspector showing stale state for up to 30 s after backend restart.

Closes #106

## Frontend pivot

The KnowledgePanel HUD (search input + result list + note viewer + vault status strip) was implemented and tested mid-PR, then explicitly removed per user decision (\"funktionalität soll alles da bleiben ich brauche nur den teil in der UI nicht\"). The backend surface is fully retained for future programmatic consumers; the HUD panel can be re-added in a later cycle alongside the broader HUD redesign.

Spec ACs **#9, #10, #14** and the frontend half of **#16** are intentionally out of scope. The 12 in-scope ACs are unit-tested or manual-only by nature (script/CLI/dream-cycle).

## Known issues — follow-up work, not blocking

1. **`obsidian_open` exit-code-0 false-positive.** When the wrong CLI is on PATH (e.g. accidental `npm install -g obsidian-cli` pulls a different package), it exits 0 with the error on stdout. OpenClaw's plugin sees success, JARVIS returns 200, the AC#16 503-fallback never triggers. No user-visible consequence in this PR (KnowledgePanel removed). Fix track: defensive output parsing or proper Yakitrak-CLI symlink probe.
2. **`OpenClawWSClient` initial-connect-failure has no auto-retry.** If the gateway is down at backend startup, `WikiClient` stays disabled until the next backend restart. The existing `_reconnect_loop` only kicks in after a drop from a live connection. Wiki routes return 503 in the meantime — graceful but suboptimal.
3. **`asyncio.get_event_loop()` in `OpenClawWSClient.call_rpc`.** Deprecated in Python 3.10+, will warn on 3.12. Replace with `asyncio.get_running_loop()` before runtime upgrade. Not breaking on 3.11.
4. **`call_rpc` + `_pending_rpc` cleanup tests missing.** Production code correctly rejects pending futures on `close()` and `_reader_loop` connection-drop, verified by code inspection. Dedicated regression tests for those two paths would be welcome cleanup.

## Test plan

- [x] `pytest tests/integrations/openclaw/ tests/api/ tests/brain/ tests/utils/ -q` → 980 passed (3 pre-existing tailscale-detection failures in `test_mcp_server.py` confirmed identical on `main`).
- [x] `cd frontend && npx tsc --noEmit` → 24 errors, all pre-existing on `main` (zero new from this branch).
- [x] `cd frontend && npm run test -- features/brain` → 58 passed, 5 files.
- [x] `cd frontend && npm run build` → success, main chunk 35.7 kB gzip.
- [x] Manual smoke: `bash scripts/init_jarvis_vault.sh` first run + idempotent re-run, REST endpoints return 200/503 correctly, KnowledgePanel was tested before removal and worked end-to-end against the live OpenClaw vault.

## Reviewer verdict
PASS — 0 critical, 2 warnings (the deprecated `get_event_loop` call and missing cleanup tests above), 2 NIT suggestions. Full report from final reviewer agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)